### PR TITLE
feat: Add odnelazm-ingest pipeline with PostgreSQL storage

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -293,6 +293,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
+
+[[package]]
 name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -312,7 +318,7 @@ dependencies = [
  "cc",
  "cfg-if",
  "constant_time_eq",
- "cpufeatures",
+ "cpufeatures 0.3.0",
 ]
 
 [[package]]
@@ -372,6 +378,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "byteorder"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -423,7 +435,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f8d983286843e49675a4b7a2d174efe136dc93a18d69130dd18198a6c167601"
 dependencies = [
  "cfg-if",
- "cpufeatures",
+ "cpufeatures 0.3.0",
  "rand_core 0.10.0",
 ]
 
@@ -571,6 +583,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -604,12 +631,36 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "cpufeatures"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crc"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5eb8a2a1cd12ab0d987a5d5e825195d372001a4094a0376319d5a0ad71c1ba0d"
+dependencies = [
+ "crc-catalog",
+]
+
+[[package]]
+name = "crc-catalog"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "217698eaf96b4a3f0bc4f3662aaa55bdf913cd54d7204591faa790070c6d0853"
 
 [[package]]
 name = "crc32fast"
@@ -737,6 +788,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -764,7 +826,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
+ "subtle",
 ]
 
 [[package]]
@@ -783,6 +847,12 @@ name = "doc-comment"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "780955b8b195a21ab8e4ac6b60dd1dbdcec1dc6c51c0617964b08c81785e12c9"
+
+[[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dtoa"
@@ -887,10 +957,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "etcetera"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "136d1b5283a1ab77bd9257427ffd09d8667ced0570b6f938942bc7568ed5b943"
+dependencies = [
+ "cfg-if",
+ "home",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "ethnum"
 version = "1.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40404c3f5f511ec4da6fe866ddf6a717c309fdbb69fbbad7b0f3edab8f2e835f"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "fallible-streaming-iterator"
@@ -933,6 +1025,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b09cf3155332e944990140d967ff5eceb70df778b34f77d8075db46e4704e6d8"
 dependencies = [
  "num-traits",
+]
+
+[[package]]
+name = "flume"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+ "spin",
 ]
 
 [[package]]
@@ -1022,6 +1125,17 @@ dependencies = [
  "futures-core",
  "futures-task",
  "futures-util",
+]
+
+[[package]]
+name = "futures-intrusive"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d930c203dd0b6ff06e0201a4a2fe9149b43c684fd4420555b26d21b1a02956f"
+dependencies = [
+ "futures-core",
+ "lock_api",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1208,6 +1322,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 
 [[package]]
+name = "hashlink"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7382cf6263419f2d8df38c55d7da83da5c18aef87fc7a7fc1fb1e344edfe14c1"
+dependencies = [
+ "hashbrown 0.15.5",
+]
+
+[[package]]
 name = "heck"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1224,6 +1347,24 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "home"
@@ -1640,6 +1781,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1656,6 +1806,28 @@ name = "libm"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.5",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e99fb7a497b1e3339bc746195567ed8d3e24945ecd636e3619d20b9de9e9149"
+dependencies = [
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1840,6 +2012,42 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.6",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-iter"
+version = "0.1.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1429034a0490724d0075ebb2bc9e875d6503c3cf69e235a8941aa757d83ef5bf"
+dependencies = [
+ "autocfg",
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
 name = "num-traits"
 version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1920,6 +2128,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "odnelazm-ingest"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "chrono",
+ "env_logger",
+ "futures",
+ "log",
+ "odnelazm",
+ "regex",
+ "serde",
+ "serde_json",
+ "sqlx",
+ "thiserror 2.0.18",
+ "tokio",
+ "uuid",
+]
+
+[[package]]
 name = "odnelazm-mcp"
 version = "1.0.0-beta.5"
 dependencies = [
@@ -1957,6 +2184,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
+
+[[package]]
 name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1974,7 +2207,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link",
 ]
@@ -1993,6 +2226,15 @@ name = "pastey"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b867cad97c0791bbd3aaa6472142568c6c9e8f71937e98379f584cfb0cf35bec"
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2104,10 +2346,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
+
+[[package]]
 name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "planus"
@@ -3007,6 +3276,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_syscall"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4666a1a60d8412eab19d94f6d13dcc9cea0a5ef4fdf6a5db306537413c661b1b"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
 name = "ref-cast"
 version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3191,6 +3469,26 @@ dependencies = [
  "quote",
  "serde_json",
  "syn 2.0.116",
+]
+
+[[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -3510,6 +3808,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha1"
+version = "0.10.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3523,6 +3843,16 @@ checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
 dependencies = [
  "errno",
  "libc",
+]
+
+[[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -3580,6 +3910,9 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "snafu"
@@ -3620,12 +3953,229 @@ dependencies = [
 ]
 
 [[package]]
+name = "spin"
+version = "0.9.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+dependencies = [
+ "lock_api",
+]
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
+
+[[package]]
 name = "sqlparser"
 version = "0.49.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4a404d0e14905361b918cb8afdb73605e25c1d5029312bd9785142dcb3aa49e"
 dependencies = [
  "log",
+]
+
+[[package]]
+name = "sqlx"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fefb893899429669dcdd979aff487bd78f4064e5e7907e4269081e0ef7d97dc"
+dependencies = [
+ "sqlx-core",
+ "sqlx-macros",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+]
+
+[[package]]
+name = "sqlx-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee6798b1838b6a0f69c007c133b8df5866302197e404e8b6ee8ed3e3a5e68dc6"
+dependencies = [
+ "base64",
+ "bytes",
+ "chrono",
+ "crc",
+ "crossbeam-queue",
+ "either",
+ "event-listener",
+ "futures-core",
+ "futures-intrusive",
+ "futures-io",
+ "futures-util",
+ "hashbrown 0.15.5",
+ "hashlink",
+ "indexmap",
+ "log",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rustls",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "url",
+ "uuid",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "sqlx-macros"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2d452988ccaacfbf5e0bdbc348fb91d7c8af5bee192173ac3636b5fb6e6715d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "sqlx-core",
+ "sqlx-macros-core",
+ "syn 2.0.116",
+]
+
+[[package]]
+name = "sqlx-macros-core"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19a9c1841124ac5a61741f96e1d9e2ec77424bf323962dd894bdb93f37d5219b"
+dependencies = [
+ "dotenvy",
+ "either",
+ "heck 0.5.0",
+ "hex",
+ "once_cell",
+ "proc-macro2",
+ "quote",
+ "serde",
+ "serde_json",
+ "sha2",
+ "sqlx-core",
+ "sqlx-mysql",
+ "sqlx-postgres",
+ "sqlx-sqlite",
+ "syn 2.0.116",
+ "tokio",
+ "url",
+]
+
+[[package]]
+name = "sqlx-mysql"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa003f0038df784eb8fecbbac13affe3da23b45194bd57dba231c8f48199c526"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "crc",
+ "digest",
+ "dotenvy",
+ "either",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-util",
+ "generic-array",
+ "hex",
+ "hkdf",
+ "hmac",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "percent-encoding",
+ "rand 0.8.6",
+ "rsa",
+ "serde",
+ "sha1",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-postgres"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db58fcd5a53cf07c184b154801ff91347e4c30d17a3562a635ff028ad5deda46"
+dependencies = [
+ "atoi",
+ "base64",
+ "bitflags",
+ "byteorder",
+ "chrono",
+ "crc",
+ "dotenvy",
+ "etcetera",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "hkdf",
+ "hmac",
+ "home",
+ "itoa",
+ "log",
+ "md-5",
+ "memchr",
+ "once_cell",
+ "rand 0.8.6",
+ "serde",
+ "serde_json",
+ "sha2",
+ "smallvec",
+ "sqlx-core",
+ "stringprep",
+ "thiserror 2.0.18",
+ "tracing",
+ "uuid",
+ "whoami",
+]
+
+[[package]]
+name = "sqlx-sqlite"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2d12fe70b2c1b4401038055f90f151b78208de1f9f89a7dbfd41587a10c3eea"
+dependencies = [
+ "atoi",
+ "chrono",
+ "flume",
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-intrusive",
+ "futures-util",
+ "libsqlite3-sys",
+ "log",
+ "percent-encoding",
+ "serde",
+ "serde_urlencoded",
+ "sqlx-core",
+ "thiserror 2.0.18",
+ "tracing",
+ "url",
+ "uuid",
 ]
 
 [[package]]
@@ -3709,6 +4259,17 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
+]
+
+[[package]]
+name = "stringprep"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
+dependencies = [
+ "unicode-bidi",
+ "unicode-normalization",
+ "unicode-properties",
 ]
 
 [[package]]
@@ -4052,10 +4613,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
+name = "unicode-bidi"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-normalization"
+version = "0.1.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5fd4f6878c9cb28d874b009da9e8d183b5abc80117c40bbd187a1fde336be6e8"
+dependencies = [
+ "tinyvec",
+]
+
+[[package]]
+name = "unicode-properties"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7df058c713841ad818f1dc5d3fd88063241cc61f49f5fbea4b951e8cf5a8d71d"
 
 [[package]]
 name = "unicode-reverse"
@@ -4150,6 +4732,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4197,6 +4785,12 @@ checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
  "wit-bindgen",
 ]
+
+[[package]]
+name = "wasite"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
 
 [[package]]
 name = "wasm-bindgen"
@@ -4343,6 +4937,34 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "804f18a4ac2676ffb4e8b5b5fa9ae38af06df08162314f96a68d2a363e21a8ca"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "whoami"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d4a4db5077702ca3015d3d02d74974948aba2ad9e12ab7df718ee64ccd7e97d"
+dependencies = [
+ "libredox",
+ "wasite",
 ]
 
 [[package]]
@@ -4510,6 +5132,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
@@ -4548,6 +5179,21 @@ dependencies = [
  "windows_x86_64_gnu 0.42.2",
  "windows_x86_64_gnullvm 0.42.2",
  "windows_x86_64_msvc 0.42.2",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -4591,6 +5237,12 @@ checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -4609,6 +5261,12 @@ checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -4624,6 +5282,12 @@ name = "windows_i686_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4657,6 +5321,12 @@ checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -4672,6 +5342,12 @@ name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -4693,6 +5369,12 @@ checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -4708,6 +5390,12 @@ name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["crates/odnelazm", "crates/odnelazm-cli", "crates/odnelazm-mcp"]
+members = ["crates/odnelazm", "crates/odnelazm-cli", "crates/odnelazm-mcp", "crates/odnelazm-ingest"]
 resolver = "2"
 
 

--- a/crates/odnelazm-ingest/Cargo.toml
+++ b/crates/odnelazm-ingest/Cargo.toml
@@ -1,0 +1,33 @@
+[package]
+name = "odnelazm-ingest"
+description = "Ingestion pipeline for odnelazm hansard data"
+version = "0.1.0"
+authors.workspace = true
+edition.workspace = true
+repository.workspace = true
+license.workspace = true
+
+[dependencies]
+odnelazm = { version = "1.0.0-beta.7", path = "../odnelazm" }
+async-trait = "0.1"
+chrono = { version = "0.4.43", features = ["serde"] }
+futures = "0.3"
+log = "0.4"
+regex = "1"
+serde = { version = "1.0.228", features = ["derive"] }
+serde_json = "1.0"
+sqlx = { version = "0.8", features = [
+  "postgres",
+  "runtime-tokio-rustls",
+  "uuid",
+  "chrono",
+  "json",
+] }
+thiserror = "2"
+tokio = { version = "1.49.0", features = ["macros", "rt-multi-thread"] }
+uuid = { version = "1", features = ["v4"] }
+env_logger = "0.11"
+
+[[bin]]
+name = "ingest"
+path = "src/bin/ingest.rs"

--- a/crates/odnelazm-ingest/migrations/0001_init.sql
+++ b/crates/odnelazm-ingest/migrations/0001_init.sql
@@ -1,0 +1,75 @@
+CREATE EXTENSION IF NOT EXISTS "uuid-ossp";
+
+-- Raw sitting transcripts. raw_json holds the full HansardSitting payload so
+-- nothing is lost; the other columns are indexed projections for fast querying.
+CREATE TABLE IF NOT EXISTS sittings (
+    id           UUID        PRIMARY KEY DEFAULT uuid_generate_v4(),
+    url          TEXT        NOT NULL UNIQUE,
+    house        TEXT        NOT NULL,
+    date         DATE        NOT NULL,
+    session_type TEXT        NOT NULL,
+    source       TEXT        NOT NULL,
+    summary      TEXT,
+    sentiment    TEXT,
+    pdf_url      TEXT,
+    raw_json     JSONB       NOT NULL,
+    -- Embeddings stored as a JSON float array. Migrate to pgvector REAL[] once
+    -- the extension is available for efficient similarity search.
+    embedding    JSONB,
+    ingested_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS sittings_date_idx   ON sittings (date);
+CREATE INDEX IF NOT EXISTS sittings_house_idx  ON sittings (house);
+CREATE INDEX IF NOT EXISTS sittings_source_idx ON sittings (source);
+
+-- People who spoke in a sitting, extracted directly from contribution records.
+-- url links back to their mzalendo profile when available.
+CREATE TABLE IF NOT EXISTS speakers (
+    id   UUID PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name TEXT NOT NULL,
+    url  TEXT,
+    UNIQUE (name, url)
+);
+
+-- Join table: which speakers were active in which sittings, and how many times.
+CREATE TABLE IF NOT EXISTS sitting_speakers (
+    sitting_id   UUID NOT NULL REFERENCES sittings(id)  ON DELETE CASCADE,
+    speaker_id   UUID NOT NULL REFERENCES speakers(id)  ON DELETE CASCADE,
+    speech_count INT  NOT NULL DEFAULT 1,
+    PRIMARY KEY (sitting_id, speaker_id)
+);
+
+-- One row per distinct bill. name is the canonical identity key because
+-- bill_number is not always extractable from transcript text.
+CREATE TABLE IF NOT EXISTS bills (
+    id          UUID        PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name        TEXT        NOT NULL UNIQUE,
+    bill_number TEXT,
+    year        INT,
+    sponsor     TEXT,
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Each row is one appearance of a bill in one sitting at a particular stage.
+-- A bill may appear multiple times in the same sitting (e.g. Second Reading
+-- then Committee Stage on the same day), distinguished by stage.
+--
+-- The (bill_id, sitting_id, stage) triplet forms the natural graph edge:
+--   Bill ──[stage, date, house]──▶ Sitting
+-- Query all rows for a bill ordered by date to reconstruct its legislative journey.
+CREATE TABLE IF NOT EXISTS bill_mentions (
+    id            UUID        PRIMARY KEY DEFAULT uuid_generate_v4(),
+    bill_id       UUID        NOT NULL REFERENCES bills(id)    ON DELETE CASCADE,
+    sitting_id    UUID        NOT NULL REFERENCES sittings(id) ON DELETE CASCADE,
+    house         TEXT        NOT NULL,
+    date          DATE        NOT NULL,
+    stage         TEXT,
+    section_title TEXT        NOT NULL,
+    speech_count  INT         NOT NULL DEFAULT 0,
+    UNIQUE (bill_id, sitting_id, stage)
+);
+
+CREATE INDEX IF NOT EXISTS bill_mentions_bill_idx    ON bill_mentions (bill_id);
+CREATE INDEX IF NOT EXISTS bill_mentions_sitting_idx ON bill_mentions (sitting_id);
+CREATE INDEX IF NOT EXISTS bill_mentions_date_idx    ON bill_mentions (date);

--- a/crates/odnelazm-ingest/migrations/0002_bill_speakers.sql
+++ b/crates/odnelazm-ingest/migrations/0002_bill_speakers.sql
@@ -1,0 +1,20 @@
+-- Per-bill-per-sitting discussion summary. Nullable; populated by an AI
+-- enrichment pass after initial ingestion.
+ALTER TABLE bill_mentions ADD COLUMN IF NOT EXISTS summary TEXT;
+
+-- Which speakers contributed to a specific bill mention (i.e. spoke during
+-- that bill's debate segment in that sitting). This makes it possible to ask:
+--   "Who spoke about bill X in sitting Y?"
+--   "Across all sittings, which members have debated bill X?"
+CREATE TABLE IF NOT EXISTS bill_mention_speakers (
+    bill_mention_id UUID NOT NULL REFERENCES bill_mentions(id) ON DELETE CASCADE,
+    speaker_id      UUID NOT NULL REFERENCES speakers(id)      ON DELETE CASCADE,
+    speech_count    INT  NOT NULL DEFAULT 1,
+    PRIMARY KEY (bill_mention_id, speaker_id)
+);
+
+CREATE INDEX IF NOT EXISTS bill_mention_speakers_speaker_idx
+    ON bill_mention_speakers (speaker_id);
+
+CREATE INDEX IF NOT EXISTS bill_mention_speakers_mention_idx
+    ON bill_mention_speakers (bill_mention_id);

--- a/crates/odnelazm-ingest/migrations/0003_dedupe_speakers.sql
+++ b/crates/odnelazm-ingest/migrations/0003_dedupe_speakers.sql
@@ -1,0 +1,130 @@
+-- Speaker deduplication
+--
+-- Two classes of duplicates exist:
+--
+-- 1. Same person, different name variants — same profile URL, many name spellings.
+--    For each URL group, we elect the most-referenced row as canonical, merge
+--    speech counts into it, and delete the rest.
+--
+-- 2. Same name, null URL — the UNIQUE(name, url) constraint treats each NULL as
+--    distinct, so "Hon. Kuria Kimani" can exist hundreds of times. We collapse
+--    these to one row per distinct name and merge references.
+--
+-- After deduplication, the constraint is changed to NULLS NOT DISTINCT so future
+-- inserts correctly upsert instead of inserting duplicates.
+
+-- ── Step 1: URL-based deduplication ──────────────────────────────────────────
+
+CREATE TEMP TABLE url_canonical AS
+WITH ref_counts AS (
+    SELECT speaker_id, count(*) AS refs
+    FROM (
+        SELECT speaker_id FROM sitting_speakers
+        UNION ALL
+        SELECT speaker_id FROM bill_mention_speakers
+    ) r
+    GROUP BY speaker_id
+),
+ranked AS (
+    SELECT sp.id, sp.url,
+           row_number() OVER (
+               PARTITION BY sp.url
+               ORDER BY coalesce(rc.refs, 0) DESC, sp.id
+           ) AS rn
+    FROM speakers sp
+    LEFT JOIN ref_counts rc ON rc.speaker_id = sp.id
+    WHERE sp.url IS NOT NULL
+)
+SELECT id AS canonical_id, url FROM ranked WHERE rn = 1;
+
+-- Merge sitting_speakers into canonical rows
+INSERT INTO sitting_speakers (sitting_id, speaker_id, speech_count)
+SELECT ss.sitting_id, uc.canonical_id, ss.speech_count
+FROM sitting_speakers ss
+JOIN speakers sp ON sp.id = ss.speaker_id
+JOIN url_canonical uc ON uc.url = sp.url
+WHERE sp.id <> uc.canonical_id
+ON CONFLICT (sitting_id, speaker_id)
+    DO UPDATE SET speech_count = sitting_speakers.speech_count + EXCLUDED.speech_count;
+
+DELETE FROM sitting_speakers ss
+USING speakers sp
+JOIN url_canonical uc ON uc.url = sp.url
+WHERE ss.speaker_id = sp.id AND sp.id <> uc.canonical_id;
+
+-- Merge bill_mention_speakers into canonical rows
+INSERT INTO bill_mention_speakers (bill_mention_id, speaker_id, speech_count)
+SELECT bms.bill_mention_id, uc.canonical_id, bms.speech_count
+FROM bill_mention_speakers bms
+JOIN speakers sp ON sp.id = bms.speaker_id
+JOIN url_canonical uc ON uc.url = sp.url
+WHERE sp.id <> uc.canonical_id
+ON CONFLICT (bill_mention_id, speaker_id)
+    DO UPDATE SET speech_count = bill_mention_speakers.speech_count + EXCLUDED.speech_count;
+
+DELETE FROM bill_mention_speakers bms
+USING speakers sp
+JOIN url_canonical uc ON uc.url = sp.url
+WHERE bms.speaker_id = sp.id AND sp.id <> uc.canonical_id;
+
+-- Delete non-canonical URL-based speaker rows
+DELETE FROM speakers sp
+USING url_canonical uc
+WHERE sp.url = uc.url AND sp.id <> uc.canonical_id;
+
+-- ── Step 2: Null-URL deduplication (same name, many rows) ────────────────────
+
+CREATE TEMP TABLE null_url_dupes AS
+WITH ranked AS (
+    SELECT id, name,
+           row_number() OVER (PARTITION BY name ORDER BY id) AS rn
+    FROM speakers
+    WHERE url IS NULL
+)
+SELECT id FROM ranked WHERE rn > 1;
+
+CREATE TEMP TABLE null_url_canonical AS
+SELECT DISTINCT ON (name) id AS canonical_id, name
+FROM speakers
+WHERE url IS NULL
+ORDER BY name, id;
+
+INSERT INTO sitting_speakers (sitting_id, speaker_id, speech_count)
+SELECT ss.sitting_id, nuc.canonical_id, ss.speech_count
+FROM sitting_speakers ss
+JOIN speakers sp ON sp.id = ss.speaker_id
+JOIN null_url_canonical nuc ON nuc.name = sp.name
+WHERE sp.url IS NULL AND sp.id <> nuc.canonical_id
+ON CONFLICT (sitting_id, speaker_id)
+    DO UPDATE SET speech_count = sitting_speakers.speech_count + EXCLUDED.speech_count;
+
+DELETE FROM sitting_speakers ss
+USING speakers sp
+JOIN null_url_canonical nuc ON nuc.name = sp.name
+WHERE ss.speaker_id = sp.id
+  AND sp.url IS NULL
+  AND sp.id <> nuc.canonical_id;
+
+INSERT INTO bill_mention_speakers (bill_mention_id, speaker_id, speech_count)
+SELECT bms.bill_mention_id, nuc.canonical_id, bms.speech_count
+FROM bill_mention_speakers bms
+JOIN speakers sp ON sp.id = bms.speaker_id
+JOIN null_url_canonical nuc ON nuc.name = sp.name
+WHERE sp.url IS NULL AND sp.id <> nuc.canonical_id
+ON CONFLICT (bill_mention_id, speaker_id)
+    DO UPDATE SET speech_count = bill_mention_speakers.speech_count + EXCLUDED.speech_count;
+
+DELETE FROM bill_mention_speakers bms
+USING speakers sp
+JOIN null_url_canonical nuc ON nuc.name = sp.name
+WHERE bms.speaker_id = sp.id
+  AND sp.url IS NULL
+  AND sp.id <> nuc.canonical_id;
+
+DELETE FROM speakers WHERE id IN (SELECT id FROM null_url_dupes);
+
+-- ── Step 3: Fix unique constraint to prevent future null duplicates ───────────
+
+ALTER TABLE speakers DROP CONSTRAINT IF EXISTS speakers_name_url_key;
+ALTER TABLE speakers ADD CONSTRAINT speakers_name_url_unique
+    UNIQUE NULLS NOT DISTINCT (name, url);

--- a/crates/odnelazm-ingest/migrations/0004_members.sql
+++ b/crates/odnelazm-ingest/migrations/0004_members.sql
@@ -1,0 +1,157 @@
+CREATE EXTENSION IF NOT EXISTS pg_trgm;
+
+-- ── Members ───────────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS members (
+    id           UUID        PRIMARY KEY DEFAULT uuid_generate_v4(),
+    name         TEXT        NOT NULL,
+    url          TEXT        NOT NULL UNIQUE,
+    house        TEXT        NOT NULL,
+    parliament   TEXT        NOT NULL DEFAULT '13th-parliament',
+    role         TEXT,
+    constituency TEXT
+);
+
+-- GIN index for fast trigram search (used by match_member)
+CREATE INDEX IF NOT EXISTS members_name_trgm_idx ON members USING gin (name gin_trgm_ops);
+CREATE INDEX IF NOT EXISTS members_url_idx       ON members (url);
+
+-- ── Speaker → Member link ─────────────────────────────────────────────────────
+
+ALTER TABLE speakers
+    ADD COLUMN IF NOT EXISTS member_id UUID REFERENCES members(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS speakers_member_id_idx ON speakers (member_id);
+
+-- ── Helper: clean a raw speaker name into a matchable core name ───────────────
+--
+-- Handles patterns like:
+--   "Hon. Kimani Kuria (Molo, UDA)"         → "Kimani Kuria"
+--   "The Temporary Speaker (Hon. P. Kaluma)" → "P. Kaluma"
+--   "Sen. (Prof.) Lonyangapuo"               → "Lonyangapuo"
+
+CREATE OR REPLACE FUNCTION clean_speaker_name(raw TEXT)
+RETURNS TEXT
+LANGUAGE sql IMMUTABLE STRICT AS $$
+    SELECT regexp_replace(
+    regexp_replace(
+    regexp_replace(
+    regexp_replace(
+    regexp_replace(
+    regexp_replace(
+    regexp_replace(
+    regexp_replace(
+        trim(raw),
+        -- 1. Strip presiding-role prefix: "The (Temporary) (Deputy) Speaker/Chairman ..."
+        '^The\s+(Temporary\s+)?(Deputy\s+)?(Speaker|Chairman|Chairlady|Chair|Deputy\s+Speaker)\s*',
+        '', 'i'),
+        -- 2. Unwrap remaining lone parenthetical: "(Hon. Peter Kaluma)" → "Hon. Peter Kaluma"
+        '^\s*\(([^)]+)\)\s*$', '\1'),
+        -- 3. Strip honorifics
+        '\m(Hon|Sen|Mr|Mrs|Ms|Madam|Mhe)\.?\s*', '', 'gi'),
+        -- 4. Strip academic/professional titles (standalone or in parens)
+        '\(?(Dr|Prof|Eng|Rtd|SC|EGH|CBS|OGW|MBS|EBS|HSC|OBS)\.?\)?\s*', '', 'gi'),
+        -- 5. Strip constituency / party parenthetical at end: "(Molo, UDA)"
+        '\s*\([^)]*\)\s*$', ''),
+        -- 6. Strip trailing noise: stray ): ; chars
+        '[:\);,]+\s*$', ''),
+        -- 7. Strip possessives
+        '''s?\s', ' '),
+        -- 8. Collapse whitespace
+        '\s+', ' ')
+$$;
+
+-- ── Core function: match a raw speaker name to members ────────────────────────
+--
+-- Strategy (in order of preference):
+--   1. word_similarity on cleaned name  — handles abbreviated first/last names
+--   2. plain similarity on cleaned name — fallback
+--
+-- word_similarity(a, b) = max similarity between a and any trigram substring of b,
+-- making it ideal when the query is a short form of the full member name.
+
+CREATE OR REPLACE FUNCTION match_member(
+    query_name TEXT,
+    min_score  FLOAT DEFAULT 0.3
+)
+RETURNS TABLE (
+    id           UUID,
+    name         TEXT,
+    url          TEXT,
+    house        TEXT,
+    constituency TEXT,
+    score        FLOAT
+)
+LANGUAGE sql STABLE AS $$
+    WITH cleaned AS (
+        SELECT clean_speaker_name(query_name) AS cn
+    )
+    SELECT
+        m.id,
+        m.name,
+        m.url,
+        m.house,
+        m.constituency,
+        greatest(
+            word_similarity(c.cn, m.name),
+            similarity(c.cn, m.name)
+        )::FLOAT AS score
+    FROM members m, cleaned c
+    WHERE greatest(
+              word_similarity(c.cn, m.name),
+              similarity(c.cn, m.name)
+          ) >= min_score
+    ORDER BY score DESC
+    LIMIT 5
+$$;
+
+-- ── Linkage: wire speakers to members ────────────────────────────────────────
+--
+-- Step 1 — exact URL match (run immediately; re-runs are safe via IS NULL guard)
+-- Called by the pipeline after importing members.
+
+CREATE OR REPLACE FUNCTION link_speakers_by_url()
+RETURNS BIGINT
+LANGUAGE sql AS $$
+    WITH updated AS (
+        UPDATE speakers sp
+        SET    member_id = m.id
+        FROM   members m
+        WHERE  sp.url = m.url
+          AND  sp.member_id IS NULL
+        RETURNING 1
+    )
+    SELECT count(*)::BIGINT FROM updated
+$$;
+
+-- Step 2 — name-based fuzzy match for speakers without a URL
+-- Only matches where the best score is ≥ 0.45 (tuned to reduce false positives).
+
+CREATE OR REPLACE FUNCTION link_speakers_by_name(min_score FLOAT DEFAULT 0.45)
+RETURNS BIGINT
+LANGUAGE plpgsql AS $$
+DECLARE
+    linked BIGINT := 0;
+BEGIN
+    WITH best_match AS (
+        SELECT
+            sp.id AS speaker_id,
+            (SELECT mm.id
+             FROM match_member(sp.name, min_score) mm
+             ORDER BY score DESC
+             LIMIT 1) AS member_id
+        FROM speakers sp
+        WHERE sp.url IS NULL
+          AND sp.member_id IS NULL
+          AND length(sp.name) > 5
+    )
+    UPDATE speakers sp
+    SET    member_id = bm.member_id
+    FROM   best_match bm
+    WHERE  sp.id = bm.speaker_id
+      AND  bm.member_id IS NOT NULL;
+
+    GET DIAGNOSTICS linked = ROW_COUNT;
+    RETURN linked;
+END
+$$;

--- a/crates/odnelazm-ingest/migrations/0005_topics.sql
+++ b/crates/odnelazm-ingest/migrations/0005_topics.sql
@@ -1,0 +1,28 @@
+-- Parliamentary topics: questions, statements, motions, and any other
+-- subsection-level discussion that isn't a bill.
+--
+-- Each row represents one subsection from a sitting — a question asked,
+-- a statement delivered, a motion debated, etc.
+
+CREATE TABLE IF NOT EXISTS topics (
+    id           UUID        PRIMARY KEY DEFAULT uuid_generate_v4(),
+    sitting_id   UUID        NOT NULL REFERENCES sittings(id) ON DELETE CASCADE,
+    section_type TEXT        NOT NULL,
+    title        TEXT        NOT NULL,
+    speech_count INT         NOT NULL DEFAULT 0,
+    UNIQUE (sitting_id, section_type, title)
+);
+
+CREATE INDEX IF NOT EXISTS topics_sitting_idx ON topics (sitting_id);
+CREATE INDEX IF NOT EXISTS topics_section_idx ON topics (section_type);
+CREATE INDEX IF NOT EXISTS topics_title_trgm_idx ON topics USING gin (title gin_trgm_ops);
+
+-- Which speakers contributed to a topic.
+CREATE TABLE IF NOT EXISTS topic_speakers (
+    topic_id     UUID NOT NULL REFERENCES topics(id)   ON DELETE CASCADE,
+    speaker_id   UUID NOT NULL REFERENCES speakers(id) ON DELETE CASCADE,
+    speech_count INT  NOT NULL DEFAULT 1,
+    PRIMARY KEY (topic_id, speaker_id)
+);
+
+CREATE INDEX IF NOT EXISTS topic_speakers_speaker_idx ON topic_speakers (speaker_id);

--- a/crates/odnelazm-ingest/migrations/0006_contribution_text.sql
+++ b/crates/odnelazm-ingest/migrations/0006_contribution_text.sql
@@ -1,0 +1,10 @@
+-- Store the actual text each speaker contributed to a bill debate or topic,
+-- plus a nullable AI-generated summary populated by a separate enrichment pass.
+
+ALTER TABLE bill_mention_speakers
+    ADD COLUMN IF NOT EXISTS contributions_text TEXT,
+    ADD COLUMN IF NOT EXISTS summary            TEXT;
+
+ALTER TABLE topic_speakers
+    ADD COLUMN IF NOT EXISTS contributions_text TEXT,
+    ADD COLUMN IF NOT EXISTS summary            TEXT;

--- a/crates/odnelazm-ingest/migrations/0007_member_enrichment.sql
+++ b/crates/odnelazm-ingest/migrations/0007_member_enrichment.sql
@@ -1,0 +1,12 @@
+-- Additional profile data fetched from individual member profile pages.
+-- Populated by a separate enrichment pass after the member listing is imported.
+
+ALTER TABLE members
+    ADD COLUMN IF NOT EXISTS photo_url          TEXT,
+    ADD COLUMN IF NOT EXISTS biography          TEXT,
+    ADD COLUMN IF NOT EXISTS party              TEXT,
+    ADD COLUMN IF NOT EXISTS positions          JSONB,
+    ADD COLUMN IF NOT EXISTS committees         JSONB,
+    ADD COLUMN IF NOT EXISTS speeches_last_year INT,
+    ADD COLUMN IF NOT EXISTS speeches_total     INT,
+    ADD COLUMN IF NOT EXISTS bills_total        INT;

--- a/crates/odnelazm-ingest/migrations/0008_fix_bill_mentions_unique.sql
+++ b/crates/odnelazm-ingest/migrations/0008_fix_bill_mentions_unique.sql
@@ -1,0 +1,16 @@
+-- Replace the UNIQUE constraint on bill_mentions so that multiple NULL stages
+-- for the same (bill, sitting) pair are treated as duplicates, not distinct rows.
+ALTER TABLE bill_mentions
+  DROP CONSTRAINT IF EXISTS bill_mentions_bill_id_sitting_id_stage_key;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_constraint
+    WHERE conname = 'bill_mentions_bill_id_sitting_id_stage_unique'
+  ) THEN
+    ALTER TABLE bill_mentions
+      ADD CONSTRAINT bill_mentions_bill_id_sitting_id_stage_unique
+      UNIQUE NULLS NOT DISTINCT (bill_id, sitting_id, stage);
+  END IF;
+END$$;

--- a/crates/odnelazm-ingest/migrations/0009_bill_sponsor_id.sql
+++ b/crates/odnelazm-ingest/migrations/0009_bill_sponsor_id.sql
@@ -1,0 +1,13 @@
+ALTER TABLE bills ADD COLUMN IF NOT EXISTS sponsor_id UUID REFERENCES members(id);
+CREATE INDEX IF NOT EXISTS bills_sponsor_id_idx ON bills (sponsor_id);
+
+-- Link existing bills to member records via fuzzy name match.
+-- Re-running is safe: only updates rows where sponsor_id is still NULL.
+UPDATE bills b
+SET sponsor_id = (
+  SELECT id FROM match_member(b.sponsor, 0.4)
+  ORDER BY score DESC
+  LIMIT 1
+)
+WHERE b.sponsor IS NOT NULL
+  AND b.sponsor_id IS NULL;

--- a/crates/odnelazm-ingest/migrations/0010_bill_summary.sql
+++ b/crates/odnelazm-ingest/migrations/0010_bill_summary.sql
@@ -1,0 +1,3 @@
+-- Overall AI-generated summary of a bill's full legislative journey.
+-- Populated by a separate enrichment pass; null until then.
+ALTER TABLE bills ADD COLUMN IF NOT EXISTS summary TEXT;

--- a/crates/odnelazm-ingest/migrations/0011_sitting_youtube.sql
+++ b/crates/odnelazm-ingest/migrations/0011_sitting_youtube.sql
@@ -1,0 +1,3 @@
+-- YouTube URL for the live stream or archived recording of a sitting.
+-- Populated manually or via a future enrichment step.
+ALTER TABLE sittings ADD COLUMN IF NOT EXISTS youtube_url TEXT;

--- a/crates/odnelazm-ingest/src/bin/ingest.rs
+++ b/crates/odnelazm-ingest/src/bin/ingest.rs
@@ -24,6 +24,10 @@ async fn main() {
         .and_then(|s| s.parse().ok())
         .unwrap_or(4);
 
+    let parliament = std::env::var("PARLIAMENT").unwrap_or_else(|_| "13th-parliament".to_string());
+
+    let skip_members = std::env::var("SKIP_MEMBERS").is_ok();
+
     log::info!("Connecting to database...");
     let store = PostgresStore::connect(&database_url)
         .await
@@ -45,6 +49,8 @@ async fn main() {
 
     let pipeline = IngestPipeline::new(scraper, store);
 
+    // ── Sittings ──────────────────────────────────────────────────────────────
+
     let stats = match (start_date, end_date) {
         (Some(start), Some(end)) => {
             log::info!("Ingesting range {start} – {end} (concurrency={concurrency})");
@@ -60,5 +66,18 @@ async fn main() {
         std::process::exit(1);
     });
 
-    log::info!("Done — {stats}");
+    log::info!("Sittings — {stats}");
+
+    // ── Members + speaker linkage ─────────────────────────────────────────────
+
+    if !skip_members {
+        let linked = pipeline
+            .import_members(&parliament)
+            .await
+            .unwrap_or_else(|e| {
+                log::error!("Member import error: {e}");
+                std::process::exit(1);
+            });
+        log::info!("Members done — {linked} speaker→member links created");
+    }
 }

--- a/crates/odnelazm-ingest/src/bin/ingest.rs
+++ b/crates/odnelazm-ingest/src/bin/ingest.rs
@@ -1,0 +1,64 @@
+use chrono::NaiveDate;
+use odnelazm::HansardScraper;
+use odnelazm_ingest::{DataStore, IngestPipeline, PostgresStore};
+
+#[tokio::main]
+async fn main() {
+    env_logger::Builder::new()
+        .filter_level(log::LevelFilter::Info)
+        .init();
+
+    let database_url = std::env::var("DATABASE_URL")
+        .unwrap_or_else(|_| "postgres://odnelazm:odnelazm@localhost:5432/odnelazm".to_string());
+
+    let start_date = std::env::var("START_DATE")
+        .ok()
+        .and_then(|s| NaiveDate::parse_from_str(&s, "%Y-%m-%d").ok());
+
+    let end_date = std::env::var("END_DATE")
+        .ok()
+        .and_then(|s| NaiveDate::parse_from_str(&s, "%Y-%m-%d").ok());
+
+    let concurrency: usize = std::env::var("CONCURRENCY")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(4);
+
+    log::info!("Connecting to database...");
+    let store = PostgresStore::connect(&database_url)
+        .await
+        .unwrap_or_else(|e| {
+            log::error!("Failed to connect: {e}");
+            std::process::exit(1);
+        });
+
+    log::info!("Running migrations...");
+    store.migrate().await.unwrap_or_else(|e| {
+        log::error!("Migration failed: {e}");
+        std::process::exit(1);
+    });
+
+    let scraper = HansardScraper::new().unwrap_or_else(|e| {
+        log::error!("Failed to create scraper: {e}");
+        std::process::exit(1);
+    });
+
+    let pipeline = IngestPipeline::new(scraper, store);
+
+    let stats = match (start_date, end_date) {
+        (Some(start), Some(end)) => {
+            log::info!("Ingesting range {start} – {end} (concurrency={concurrency})");
+            pipeline.ingest_range(start, end, concurrency).await
+        }
+        _ => {
+            log::info!("Ingesting all current sittings (concurrency={concurrency})");
+            pipeline.ingest_all(concurrency).await
+        }
+    }
+    .unwrap_or_else(|e| {
+        log::error!("Pipeline error: {e}");
+        std::process::exit(1);
+    });
+
+    log::info!("Done — {stats}");
+}

--- a/crates/odnelazm-ingest/src/bin/ingest.rs
+++ b/crates/odnelazm-ingest/src/bin/ingest.rs
@@ -26,7 +26,9 @@ async fn main() {
 
     let parliament = std::env::var("PARLIAMENT").unwrap_or_else(|_| "13th-parliament".to_string());
 
+    let skip_sittings = std::env::var("SKIP_SITTINGS").is_ok();
     let skip_members = std::env::var("SKIP_MEMBERS").is_ok();
+    let enrich_members = std::env::var("ENRICH_MEMBERS").is_ok();
 
     log::info!("Connecting to database...");
     let store = PostgresStore::connect(&database_url)
@@ -51,24 +53,34 @@ async fn main() {
 
     // ── Sittings ──────────────────────────────────────────────────────────────
 
-    let stats = match (start_date, end_date) {
-        (Some(start), Some(end)) => {
-            log::info!("Ingesting range {start} – {end} (concurrency={concurrency})");
-            pipeline.ingest_range(start, end, concurrency).await
-        }
-        _ => {
-            log::info!("Ingesting all current sittings (concurrency={concurrency})");
-            pipeline.ingest_all(concurrency).await
-        }
+    if skip_sittings {
+        log::info!("Sittings ingest skipped (SKIP_SITTINGS)");
     }
-    .unwrap_or_else(|e| {
-        log::error!("Pipeline error: {e}");
-        std::process::exit(1);
-    });
 
-    log::info!("Sittings — {stats}");
+    if !skip_sittings {
+        let stats = match (start_date, end_date) {
+            (Some(start), Some(end)) => {
+                log::info!("Ingesting range {start} – {end} (concurrency={concurrency})");
+                pipeline.ingest_range(start, end, concurrency).await
+            }
+            _ => {
+                log::info!("Ingesting all current sittings (concurrency={concurrency})");
+                pipeline.ingest_all(concurrency).await
+            }
+        }
+        .unwrap_or_else(|e| {
+            log::error!("Pipeline error: {e}");
+            std::process::exit(1);
+        });
+        log::info!("Sittings — {stats}");
+    }
 
     // ── Members + speaker linkage ─────────────────────────────────────────────
+
+    let enrich_batch: u32 = std::env::var("ENRICH_BATCH")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(0);
 
     if !skip_members {
         let linked = pipeline
@@ -79,5 +91,29 @@ async fn main() {
                 std::process::exit(1);
             });
         log::info!("Members done — {linked} speaker→member links created");
+    }
+
+    if enrich_members {
+        let enriched = pipeline
+            .enrich_member_profiles(concurrency)
+            .await
+            .unwrap_or_else(|e| {
+                log::error!("Member enrichment error: {e}");
+                std::process::exit(1);
+            });
+        log::info!("Member profiles enriched — {enriched} updated");
+    }
+
+    // ── AI enrichment (optional, requires ENRICH_BATCH > 0 + a Summarizer) ──
+
+    if enrich_batch > 0 {
+        let (bills, topics) = pipeline
+            .enrich_summaries(enrich_batch)
+            .await
+            .unwrap_or_else(|e| {
+                log::error!("Enrichment error: {e}");
+                std::process::exit(1);
+            });
+        log::info!("Enrichment done — {bills} bill summaries, {topics} topic summaries generated");
     }
 }

--- a/crates/odnelazm-ingest/src/embed.rs
+++ b/crates/odnelazm-ingest/src/embed.rs
@@ -1,0 +1,48 @@
+use async_trait::async_trait;
+
+use crate::Result;
+
+/// Trait for generating embeddings from text.
+///
+/// Implement with your preferred provider — OpenAI, a local model, Anthropic
+/// (once they expose an embedding endpoint), etc. The pipeline calls this
+/// once per sitting using the text produced by [`sitting_text`].
+#[async_trait]
+pub trait Embedder: Send + Sync {
+    async fn embed(&self, text: &str) -> Result<Vec<f32>>;
+
+    /// Dimensionality of the vectors produced, e.g. 1536 for
+    /// text-embedding-3-small. Stored for documentation; the pipeline does
+    /// not enforce it.
+    fn dimensions(&self) -> usize;
+}
+
+/// Build the text that gets embedded for a sitting.
+///
+/// Uses `summary` when available (current sittings always have one), otherwise
+/// falls back to a concatenation of section and subsection titles. The sitting
+/// metadata (house, date, session type) is always prepended for grounding.
+pub fn sitting_text(sitting: &odnelazm::HansardSitting) -> String {
+    let header = format!(
+        "{} — {} — {}",
+        sitting.house, sitting.date, sitting.session_type
+    );
+
+    let body = if let Some(summary) = &sitting.summary {
+        summary.clone()
+    } else {
+        sitting
+            .sections
+            .iter()
+            .flat_map(|s| {
+                let mut titles = vec![s.section_type.clone()];
+                titles.extend(s.subsections.iter().map(|sub| sub.title.clone()));
+                titles
+            })
+            .filter(|t| !t.is_empty())
+            .collect::<Vec<_>>()
+            .join("\n")
+    };
+
+    format!("{header}\n\n{body}")
+}

--- a/crates/odnelazm-ingest/src/error.rs
+++ b/crates/odnelazm-ingest/src/error.rs
@@ -1,0 +1,21 @@
+use odnelazm::ScraperError;
+
+#[derive(Debug, thiserror::Error)]
+pub enum IngestError {
+    #[error("Store error: {0}")]
+    Store(String),
+    #[error("Scraper error: {0}")]
+    Scraper(#[from] ScraperError),
+    #[error("Embed error: {0}")]
+    Embed(String),
+    #[error("Serialization error: {0}")]
+    Serialize(#[from] serde_json::Error),
+}
+
+impl From<sqlx::Error> for IngestError {
+    fn from(e: sqlx::Error) -> Self {
+        IngestError::Store(e.to_string())
+    }
+}
+
+pub type Result<T> = std::result::Result<T, IngestError>;

--- a/crates/odnelazm-ingest/src/extract/bills.rs
+++ b/crates/odnelazm-ingest/src/extract/bills.rs
@@ -5,6 +5,7 @@ use regex::Regex;
 
 use odnelazm::HansardSitting;
 
+use crate::extract::speakers::is_noise_speaker;
 use crate::store::BillRecord;
 
 /// A member who spoke during a bill's debate segment.
@@ -42,6 +43,10 @@ static RE_READING: LazyLock<Regex> = LazyLock::new(|| {
     Regex::new(r"(?i)be read a (First|Second|Third) Time").expect("invalid reading regex")
 });
 
+// Normalises "No.X" / "No.  X" → "No. X" inside bill names
+static RE_BILL_NO_SPACING: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"No\.(\d)").expect("invalid bill no spacing regex"));
+
 fn stage_from_title(title: &str) -> Option<String> {
     let u = title.to_uppercase();
     if u.contains("FIRST READING") {
@@ -52,10 +57,21 @@ fn stage_from_title(title: &str) -> Option<String> {
         Some("Third Reading".into())
     } else if u.contains("COMMITTEE OF THE WHOLE HOUSE") || u.contains("IN THE COMMITTEE") {
         Some("Committee Stage".into())
-    } else if u.contains("CONSIDERATION OF REPORT") {
+    } else if u.contains("CONSIDERATION OF REPORT")
+        || u.contains("CONSIDERATION OF THE REPORT")
+        || u.contains("CONSIDERATION OF SENATE AMENDMENTS")
+        || u.contains("SENATE AMENDMENTS TO THE")
+    {
         Some("Report Stage".into())
     } else if u.contains("APPROVAL OF MEDIATED VERSION") {
         Some("Mediation Approval".into())
+    } else if u.contains("PRESIDENT'S RESERVATIONS")
+        || u.contains("AMENDMENTS RECOMMENDED BY H. E.")
+        || u.contains("PRESIDENTIAL MEMORANDA")
+    {
+        Some("Presidential Reservations".into())
+    } else if u.contains("REDUCTION OF PUBLICATION PERIOD") {
+        Some("Publication Period Reduction".into())
     } else {
         None
     }
@@ -72,22 +88,57 @@ fn stage_from_text(text: &str) -> Option<String> {
 }
 
 /// Stage prefixes that appear before the actual bill name in subsection titles.
+/// Ordered longest-first so more specific patterns are tried before generic ones.
 static STAGE_PREFIXES: &[&str] = &[
     "APPROVAL OF MEDIATED VERSION OF THE ",
+    "CONSIDERATION OF THE REPORT ON THE ",
+    "CONSIDERATION OF REPORT ON SENATE AMENDMENTS TO THE ",
+    "CONSIDERATION OF SENATE AMENDMENTS TO THE ",
+    "CONSIDERATION OF REPORT OF THE ",
     "CONSIDERATION OF REPORT ON THE ",
+    "CONSIDERATION OF THE PRESIDENT'S RESERVATIONS ON THE ",
+    "CONSIDERATION OF ",
+    "ADOPTION OF REPORT ON PETITION TO AMEND THE ",
+    "ADOPTION OF MEDIATION COMMITTEE REPORT ON THE ",
     "ADOPTION OF REPORT ON THE ",
+    "SENATE AMENDMENTS TO THE ",
+    "AMENDMENTS RECOMMENDED BY H. E. THE PRESIDENT TO THE ",
+    "PROCEDURE FOR DISPOSAL OF PRESIDENTIAL MEMORANDA ON THE ",
+    "REDUCTION OF PUBLICATION PERIOD OF THE ",
     "SECOND READING OF THE ",
     "THIRD READING OF THE ",
     "FIRST READING OF THE ",
+    "ADJOURNMENT OF DEBATE ON THE ",
+];
+
+/// Substrings that identify non-bill titles masquerading as bills.
+static EXCLUSION_PATTERNS: &[&str] = &[
+    "NG-CDF",
+    "STATUTORY PROVISION",
+    "CONSTITUENCY",
+    "BIENNIAL REPORT",
+    "MESSAGE FROM THE NATIONAL ASSEMBLY",
+    "APPOINTMENT OF MEMBERS TO MEDIATION COMMITTEE",
+    "ADJOURNMENT OF DEBATE",
 ];
 
 /// Return the canonical bill name if the title describes a bill, or None.
 fn bill_name_from_title(title: &str) -> Option<String> {
     let upper = title.trim().to_uppercase();
 
-    // Must end with BILL or ACT (common Kenyan parliamentary naming)
+    // Must end with BILL or ACT
     if !upper.ends_with("BILL") && !upper.ends_with(" ACT") {
         return None;
+    }
+
+    // Reject table-header and non-legislative titles
+    if upper.starts_with(|c: char| c.is_ascii_digit()) {
+        return None;
+    }
+    for pattern in EXCLUSION_PATTERNS {
+        if upper.contains(pattern) {
+            return None;
+        }
     }
 
     // Strip any known stage prefix
@@ -99,7 +150,25 @@ fn bill_name_from_title(title: &str) -> Option<String> {
     // Strip leading "THE "
     let stripped = stripped.strip_prefix("THE ").unwrap_or(stripped);
 
-    Some(title_case(stripped))
+    let name = title_case(stripped);
+
+    // Reject if the name doesn't start with a letter (e.g. bare "(Amendment) Bill")
+    if !name.starts_with(|c: char| c.is_alphabetic()) {
+        return None;
+    }
+
+    // Reject suspiciously short names
+    if name.len() < 8 {
+        return None;
+    }
+
+    // Normalise spacing around bill numbers: "No.2" → "No. 2"
+    let name = RE_BILL_NO_SPACING.replace_all(&name, "No. $1").to_string();
+
+    // Normalise possessives: "Judges'" → "Judges"
+    let name = name.replace("s' ", "s ").replace("'s ", "s ");
+
+    Some(name)
 }
 
 fn title_case(s: &str) -> String {
@@ -136,6 +205,9 @@ fn tally_contributors<'a>(
 ) -> Vec<BillContributor> {
     let mut counts: HashMap<(String, Option<String>), u32> = HashMap::new();
     for c in contribs {
+        if is_noise_speaker(&c.speaker_name) {
+            continue;
+        }
         *counts
             .entry((c.speaker_name.clone(), c.speaker_url.clone()))
             .or_default() += 1;

--- a/crates/odnelazm-ingest/src/extract/bills.rs
+++ b/crates/odnelazm-ingest/src/extract/bills.rs
@@ -1,0 +1,357 @@
+use std::collections::HashMap;
+use std::sync::LazyLock;
+
+use regex::Regex;
+
+use odnelazm::HansardSitting;
+
+use crate::store::BillRecord;
+
+/// A member who spoke during a bill's debate segment.
+#[derive(Debug, Clone)]
+pub struct BillContributor {
+    pub name: String,
+    pub url: Option<String>,
+    pub speech_count: u32,
+}
+
+/// An extracted bill mention ready to be handed to the pipeline.
+#[derive(Debug, Clone)]
+pub struct ExtractedBillMention {
+    pub bill: BillRecord,
+    /// Legislative stage detected from title or contribution text.
+    pub stage: Option<String>,
+    /// The section / subsection title this mention was found under.
+    pub section_title: String,
+    /// Number of contributions in this debate segment.
+    pub speech_count: u32,
+    /// Members who spoke during this bill's debate segment.
+    pub contributors: Vec<BillContributor>,
+}
+
+// Matches formal bill numbers in contribution text.
+// e.g. "National Assembly Bill No.20 of 2026" or "Senate Bill No. 5 of 2025"
+static RE_BILL_NUMBER: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)(National Assembly|Senate)\s+Bill\s+No\.?\s*(\d+)\s+of\s+(\d{4})")
+        .expect("invalid bill number regex")
+});
+
+// Matches reading stage in contribution text.
+// e.g. "be read a Second Time"
+static RE_READING: LazyLock<Regex> = LazyLock::new(|| {
+    Regex::new(r"(?i)be read a (First|Second|Third) Time").expect("invalid reading regex")
+});
+
+fn stage_from_title(title: &str) -> Option<String> {
+    let u = title.to_uppercase();
+    if u.contains("FIRST READING") {
+        Some("First Reading".into())
+    } else if u.contains("SECOND READING") {
+        Some("Second Reading".into())
+    } else if u.contains("THIRD READING") {
+        Some("Third Reading".into())
+    } else if u.contains("COMMITTEE OF THE WHOLE HOUSE") || u.contains("IN THE COMMITTEE") {
+        Some("Committee Stage".into())
+    } else if u.contains("CONSIDERATION OF REPORT") {
+        Some("Report Stage".into())
+    } else if u.contains("APPROVAL OF MEDIATED VERSION") {
+        Some("Mediation Approval".into())
+    } else {
+        None
+    }
+}
+
+fn stage_from_text(text: &str) -> Option<String> {
+    if let Some(caps) = RE_READING.captures(text) {
+        return Some(format!("{} Reading", title_case(&caps[1])));
+    }
+    if text.to_uppercase().contains("COMMITTEE OF THE WHOLE HOUSE") {
+        return Some("Committee Stage".into());
+    }
+    None
+}
+
+/// Stage prefixes that appear before the actual bill name in subsection titles.
+static STAGE_PREFIXES: &[&str] = &[
+    "APPROVAL OF MEDIATED VERSION OF THE ",
+    "CONSIDERATION OF REPORT ON THE ",
+    "ADOPTION OF REPORT ON THE ",
+    "SECOND READING OF THE ",
+    "THIRD READING OF THE ",
+    "FIRST READING OF THE ",
+];
+
+/// Return the canonical bill name if the title describes a bill, or None.
+fn bill_name_from_title(title: &str) -> Option<String> {
+    let upper = title.trim().to_uppercase();
+
+    // Must end with BILL or ACT (common Kenyan parliamentary naming)
+    if !upper.ends_with("BILL") && !upper.ends_with(" ACT") {
+        return None;
+    }
+
+    // Strip any known stage prefix
+    let stripped = STAGE_PREFIXES
+        .iter()
+        .find_map(|prefix| upper.strip_prefix(prefix))
+        .unwrap_or(&upper);
+
+    // Strip leading "THE "
+    let stripped = stripped.strip_prefix("THE ").unwrap_or(stripped);
+
+    Some(title_case(stripped))
+}
+
+fn title_case(s: &str) -> String {
+    s.split_whitespace()
+        .map(|word| {
+            // Strip leading punctuation like '(' to capitalise the letter, then reattach.
+            let (prefix, rest) =
+                word.split_at(word.find(|c: char| c.is_alphabetic()).unwrap_or(word.len()));
+            let mut chars = rest.chars();
+            match chars.next() {
+                None => prefix.to_string(),
+                Some(first) => {
+                    format!(
+                        "{}{}{}",
+                        prefix,
+                        first.to_uppercase(),
+                        chars.as_str().to_lowercase()
+                    )
+                }
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn extract_bill_number(text: &str) -> Option<String> {
+    RE_BILL_NUMBER
+        .captures(text)
+        .map(|caps| caps[0].split_whitespace().collect::<Vec<_>>().join(" "))
+}
+
+fn tally_contributors<'a>(
+    contribs: impl Iterator<Item = &'a odnelazm::Contribution>,
+) -> Vec<BillContributor> {
+    let mut counts: HashMap<(String, Option<String>), u32> = HashMap::new();
+    for c in contribs {
+        *counts
+            .entry((c.speaker_name.clone(), c.speaker_url.clone()))
+            .or_default() += 1;
+    }
+    counts
+        .into_iter()
+        .map(|((name, url), speech_count)| BillContributor {
+            name,
+            url,
+            speech_count,
+        })
+        .collect()
+}
+
+/// Walk a sitting's sections and subsections and return every bill mention found.
+pub fn extract_bills(sitting: &HansardSitting) -> Vec<ExtractedBillMention> {
+    let mut mentions: Vec<ExtractedBillMention> = Vec::new();
+
+    for section in &sitting.sections {
+        // Check subsection titles
+        for subsection in &section.subsections {
+            let title = &subsection.title;
+
+            let Some(bill_name) = bill_name_from_title(title) else {
+                continue;
+            };
+
+            let contrib_text: String = subsection
+                .contributions
+                .iter()
+                .map(|c| c.content.as_str())
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            let bill_number = extract_bill_number(&contrib_text);
+            let year = bill_number.as_ref().and_then(|n| {
+                RE_BILL_NUMBER
+                    .captures(n)
+                    .and_then(|c| c[3].parse::<i32>().ok())
+            });
+
+            let sponsor = subsection.contributions.iter().find_map(|c| {
+                if c.content.contains("I beg to move") {
+                    Some(c.speaker_name.clone())
+                } else {
+                    None
+                }
+            });
+
+            let stage = stage_from_title(title).or_else(|| stage_from_text(&contrib_text));
+            let contributors = tally_contributors(subsection.contributions.iter());
+
+            mentions.push(ExtractedBillMention {
+                bill: BillRecord {
+                    name: bill_name,
+                    bill_number,
+                    year,
+                    sponsor,
+                },
+                stage,
+                section_title: title.clone(),
+                speech_count: subsection.contributions.len() as u32,
+                contributors,
+            });
+        }
+
+        // Check the section_type itself (archive-style flat sections)
+        if section.subsections.is_empty()
+            && let Some(bill_name) = bill_name_from_title(&section.section_type)
+        {
+            let contrib_text: String = section
+                .contributions
+                .iter()
+                .map(|c| c.content.as_str())
+                .collect::<Vec<_>>()
+                .join("\n");
+
+            let bill_number = extract_bill_number(&contrib_text);
+            let year = bill_number.as_ref().and_then(|n| {
+                RE_BILL_NUMBER
+                    .captures(n)
+                    .and_then(|c| c[3].parse::<i32>().ok())
+            });
+
+            let sponsor = section.contributions.iter().find_map(|c| {
+                if c.content.contains("I beg to move") {
+                    Some(c.speaker_name.clone())
+                } else {
+                    None
+                }
+            });
+
+            let stage =
+                stage_from_title(&section.section_type).or_else(|| stage_from_text(&contrib_text));
+            let contributors = tally_contributors(section.contributions.iter());
+
+            mentions.push(ExtractedBillMention {
+                bill: BillRecord {
+                    name: bill_name,
+                    bill_number,
+                    year,
+                    sponsor,
+                },
+                stage,
+                section_title: section.section_type.clone(),
+                speech_count: section.contributions.len() as u32,
+                contributors,
+            });
+        }
+    }
+
+    mentions
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::extract::speakers::extract_speakers;
+
+    fn load_sitting(path: &str) -> odnelazm::HansardSitting {
+        let json = std::fs::read_to_string(path).unwrap_or_else(|_| panic!("cannot read {path}"));
+        serde_json::from_str(&json).unwrap_or_else(|e| panic!("deserialize {path}: {e}"))
+    }
+
+    #[test]
+    fn extraction_against_current_sitting() {
+        let path = "/tmp/current_sitting.json";
+        if !std::path::Path::new(path).exists() {
+            eprintln!("skip: {path} not present");
+            return;
+        }
+        let sitting = load_sitting(path);
+
+        println!("\n=== SITTING: {} {} ===\n", sitting.house, sitting.date);
+
+        let bills = extract_bills(&sitting);
+        println!("── Bills found: {} ──", bills.len());
+        for b in &bills {
+            println!("  name:         {}", b.bill.name);
+            if let Some(n) = &b.bill.bill_number {
+                println!("  bill_number:  {n}");
+            }
+            if let Some(y) = b.bill.year {
+                println!("  year:         {y}");
+            }
+            if let Some(s) = &b.bill.sponsor {
+                println!("  sponsor:      {s}");
+            }
+            println!(
+                "  stage:        {}",
+                b.stage.as_deref().unwrap_or("(unknown)")
+            );
+            println!("  section:      {}", b.section_title);
+            println!("  speeches:     {}", b.speech_count);
+            println!();
+        }
+
+        let speakers = extract_speakers(&sitting);
+        println!("── Speakers found: {} ──", speakers.len());
+        let mut sorted = speakers.clone();
+        sorted.sort_by(|a, b| b.1.cmp(&a.1));
+        for (sp, count) in sorted.iter().take(10) {
+            println!(
+                "  {:>3} speech(es)  {}{}",
+                count,
+                sp.name,
+                sp.url
+                    .as_deref()
+                    .map(|u| format!("  [{u}]"))
+                    .unwrap_or_default()
+            );
+        }
+        if speakers.len() > 10 {
+            println!("  ... and {} more", speakers.len() - 10);
+        }
+    }
+
+    #[test]
+    fn bill_name_from_subsection_title() {
+        assert_eq!(
+            bill_name_from_title("THE INCOME TAX (AMENDMENT) BILL"),
+            Some("Income Tax (Amendment) Bill".into())
+        );
+        assert_eq!(
+            bill_name_from_title(
+                "APPROVAL OF MEDIATED VERSION OF THE NATIONAL DISASTER RISK MANAGEMENT BILL"
+            ),
+            Some("National Disaster Risk Management Bill".into())
+        );
+        assert_eq!(
+            bill_name_from_title(
+                "CONSIDERATION OF REPORT ON THE FOREST CONSERVATION AND MANAGEMENT (AMENDMENT) BILL"
+            ),
+            Some("Forest Conservation And Management (Amendment) Bill".into())
+        );
+        assert_eq!(
+            bill_name_from_title("KILLING OF CIVILIANS IN MWINGI NORTH"),
+            None
+        );
+    }
+
+    #[test]
+    fn stage_from_contribution_text() {
+        assert_eq!(
+            stage_from_text("I beg to move that the Bill be read a Second Time."),
+            Some("Second Reading".into())
+        );
+        assert_eq!(stage_from_text("No stage here."), None);
+    }
+
+    #[test]
+    fn bill_number_regex() {
+        let text = "the Income Tax (Amendment) Bill (National Assembly Bill No.20 of 2026) be read";
+        assert_eq!(
+            extract_bill_number(text),
+            Some("National Assembly Bill No.20 of 2026".into())
+        );
+    }
+}

--- a/crates/odnelazm-ingest/src/extract/bills.rs
+++ b/crates/odnelazm-ingest/src/extract/bills.rs
@@ -14,6 +14,8 @@ pub struct BillContributor {
     pub name: String,
     pub url: Option<String>,
     pub speech_count: u32,
+    /// Concatenated text of all this speaker's contributions in the segment.
+    pub contributions_text: String,
 }
 
 /// An extracted bill mention ready to be handed to the pipeline.
@@ -203,21 +205,25 @@ fn extract_bill_number(text: &str) -> Option<String> {
 fn tally_contributors<'a>(
     contribs: impl Iterator<Item = &'a odnelazm::Contribution>,
 ) -> Vec<BillContributor> {
-    let mut counts: HashMap<(String, Option<String>), u32> = HashMap::new();
+    type Key = (String, Option<String>);
+    type Val<'b> = (u32, Vec<&'b str>);
+    let mut map: HashMap<Key, Val<'a>> = HashMap::new();
     for c in contribs {
         if is_noise_speaker(&c.speaker_name) {
             continue;
         }
-        *counts
+        let entry = map
             .entry((c.speaker_name.clone(), c.speaker_url.clone()))
-            .or_default() += 1;
+            .or_default();
+        entry.0 += 1;
+        entry.1.push(c.content.as_str());
     }
-    counts
-        .into_iter()
-        .map(|((name, url), speech_count)| BillContributor {
+    map.into_iter()
+        .map(|((name, url), (speech_count, texts))| BillContributor {
             name,
             url,
             speech_count,
+            contributions_text: texts.join("\n\n"),
         })
         .collect()
 }

--- a/crates/odnelazm-ingest/src/extract/mod.rs
+++ b/crates/odnelazm-ingest/src/extract/mod.rs
@@ -1,5 +1,7 @@
 pub mod bills;
 pub mod speakers;
+pub mod topics;
 
 pub use bills::{ExtractedBillMention, extract_bills};
 pub use speakers::extract_speakers;
+pub use topics::{ExtractedTopic, TopicContributor, extract_topics};

--- a/crates/odnelazm-ingest/src/extract/mod.rs
+++ b/crates/odnelazm-ingest/src/extract/mod.rs
@@ -1,0 +1,5 @@
+pub mod bills;
+pub mod speakers;
+
+pub use bills::{ExtractedBillMention, extract_bills};
+pub use speakers::extract_speakers;

--- a/crates/odnelazm-ingest/src/extract/speakers.rs
+++ b/crates/odnelazm-ingest/src/extract/speakers.rs
@@ -1,0 +1,31 @@
+use std::collections::HashMap;
+
+use odnelazm::HansardSitting;
+
+use crate::store::SpeakerRecord;
+
+/// Walk every contribution in a sitting and tally speech counts per unique
+/// (name, url) pair. Returns one record per distinct speaker.
+pub fn extract_speakers(sitting: &HansardSitting) -> Vec<(SpeakerRecord, u32)> {
+    let mut counts: HashMap<(String, Option<String>), u32> = HashMap::new();
+
+    for section in &sitting.sections {
+        for contrib in &section.contributions {
+            *counts
+                .entry((contrib.speaker_name.clone(), contrib.speaker_url.clone()))
+                .or_default() += 1;
+        }
+        for subsection in &section.subsections {
+            for contrib in &subsection.contributions {
+                *counts
+                    .entry((contrib.speaker_name.clone(), contrib.speaker_url.clone()))
+                    .or_default() += 1;
+            }
+        }
+    }
+
+    counts
+        .into_iter()
+        .map(|((name, url), count)| (SpeakerRecord { name, url }, count))
+        .collect()
+}

--- a/crates/odnelazm-ingest/src/extract/speakers.rs
+++ b/crates/odnelazm-ingest/src/extract/speakers.rs
@@ -4,22 +4,70 @@ use odnelazm::HansardSitting;
 
 use crate::store::SpeakerRecord;
 
+/// Returns true for names that should never be stored as speakers:
+/// - Collective address terms ("Hon. Members", "Hon. Senators")
+/// - Presiding-role-plus-motion artifacts ("Hon. Speaker, I beg to move")
+/// - Bare role fragments ("Hon", "Sen")
+/// - Digits-first garbage (table row leakage)
+/// - Excessively long names (multiple lines merged by the parser)
+pub fn is_noise_speaker(name: &str) -> bool {
+    let t = name.trim();
+
+    if t.len() < 4 {
+        return true;
+    }
+    if t.starts_with(|c: char| c.is_ascii_digit()) {
+        return true;
+    }
+    // Parser artefact: role label concatenated with opening motion phrase
+    if t.contains("I beg to move") {
+        return true;
+    }
+    // Implausibly long — almost certainly a multi-line parse error
+    if t.len() > 150 {
+        return true;
+    }
+
+    let lower = t.to_lowercase();
+    matches!(
+        lower.as_str(),
+        "hon"
+            | "hon."
+            | "sen"
+            | "sen."
+            | "hon. members"
+            | "hon members"
+            | "hon. member"
+            | "hon member"
+            | "hon. senators"
+            | "hon senators"
+            | "hon. senator"
+            | "hon senator"
+            | "hon. chairman"
+            | "hon chairman"
+    )
+}
+
 /// Walk every contribution in a sitting and tally speech counts per unique
-/// (name, url) pair. Returns one record per distinct speaker.
+/// (name, url) pair. Noise speaker names are silently skipped.
 pub fn extract_speakers(sitting: &HansardSitting) -> Vec<(SpeakerRecord, u32)> {
     let mut counts: HashMap<(String, Option<String>), u32> = HashMap::new();
 
     for section in &sitting.sections {
         for contrib in &section.contributions {
-            *counts
-                .entry((contrib.speaker_name.clone(), contrib.speaker_url.clone()))
-                .or_default() += 1;
-        }
-        for subsection in &section.subsections {
-            for contrib in &subsection.contributions {
+            if !is_noise_speaker(&contrib.speaker_name) {
                 *counts
                     .entry((contrib.speaker_name.clone(), contrib.speaker_url.clone()))
                     .or_default() += 1;
+            }
+        }
+        for subsection in &section.subsections {
+            for contrib in &subsection.contributions {
+                if !is_noise_speaker(&contrib.speaker_name) {
+                    *counts
+                        .entry((contrib.speaker_name.clone(), contrib.speaker_url.clone()))
+                        .or_default() += 1;
+                }
             }
         }
     }

--- a/crates/odnelazm-ingest/src/extract/topics.rs
+++ b/crates/odnelazm-ingest/src/extract/topics.rs
@@ -1,0 +1,147 @@
+use std::collections::HashMap;
+
+use odnelazm::HansardSitting;
+
+use crate::extract::speakers::is_noise_speaker;
+use crate::store::SpeakerRecord;
+
+pub struct TopicContributor {
+    pub speaker: SpeakerRecord,
+    pub speech_count: u32,
+    pub contributions_text: String,
+}
+
+/// Section types we extract as topics. Order matters — more specific first.
+static TOPIC_SECTION_TYPES: &[&str] = &[
+    "QUESTIONS AND STATEMENTS",
+    "STATEMENTS",
+    "STATEMENT",
+    "NOTICES OF MOTIONS",
+    "NOTICES OF MOTION",
+    "NOTICE OF MOTION",
+    "COMMUNICATION FROM THE CHAIR",
+    "COMMUNICATIONS FROM THE CHAIR",
+    "ADJOURNMENT",
+];
+
+/// A non-bill discussion topic extracted from a sitting (question, statement, motion, etc.).
+pub struct ExtractedTopic {
+    pub section_type: String,
+    pub title: String,
+    pub speech_count: u32,
+    pub contributors: Vec<TopicContributor>,
+}
+
+fn is_topic_section(section_type: &str) -> bool {
+    let upper = section_type.trim().to_uppercase();
+    TOPIC_SECTION_TYPES.contains(&upper.as_str())
+}
+
+/// Normalise an ALL-CAPS subsection title to title case.
+fn normalise_title(raw: &str) -> String {
+    raw.split_whitespace()
+        .map(|word| {
+            let (prefix, rest) =
+                word.split_at(word.find(|c: char| c.is_alphabetic()).unwrap_or(word.len()));
+            let mut chars = rest.chars();
+            match chars.next() {
+                None => prefix.to_string(),
+                Some(first) => format!(
+                    "{}{}{}",
+                    prefix,
+                    first.to_uppercase(),
+                    chars.as_str().to_lowercase()
+                ),
+            }
+        })
+        .collect::<Vec<_>>()
+        .join(" ")
+}
+
+fn tally_speakers<'a>(
+    contribs: impl Iterator<Item = &'a odnelazm::Contribution>,
+) -> Vec<TopicContributor> {
+    type Key = (String, Option<String>);
+    type Val<'b> = (u32, Vec<&'b str>);
+    let mut map: HashMap<Key, Val<'a>> = HashMap::new();
+    for c in contribs {
+        if is_noise_speaker(&c.speaker_name) {
+            continue;
+        }
+        let entry = map
+            .entry((c.speaker_name.clone(), c.speaker_url.clone()))
+            .or_default();
+        entry.0 += 1;
+        entry.1.push(c.content.as_str());
+    }
+    map.into_iter()
+        .map(|((name, url), (speech_count, texts))| TopicContributor {
+            speaker: SpeakerRecord { name, url },
+            speech_count,
+            contributions_text: texts.join("\n\n"),
+        })
+        .collect()
+}
+
+/// Extract questions, statements, and other non-bill discussion topics from a sitting.
+///
+/// Only subsections with at least one non-noise contribution are returned.
+/// Bill-related subsections (title ends with BILL or ACT) are skipped — those
+/// are already captured by the bill extractor.
+pub fn extract_topics(sitting: &HansardSitting) -> Vec<ExtractedTopic> {
+    let mut topics: Vec<ExtractedTopic> = Vec::new();
+
+    for section in &sitting.sections {
+        if !is_topic_section(&section.section_type) {
+            continue;
+        }
+
+        for subsection in &section.subsections {
+            let title = subsection.title.trim();
+
+            if title.is_empty() || title.len() < 5 {
+                continue;
+            }
+
+            // Skip bill/act debates — handled by the bill extractor
+            let upper = title.to_uppercase();
+            if upper.ends_with("BILL") || upper.ends_with(" ACT") {
+                continue;
+            }
+
+            let contributors = tally_speakers(subsection.contributions.iter());
+            let speech_count = subsection.contributions.len() as u32;
+
+            // Skip subsections with no meaningful contributions
+            if contributors.is_empty() {
+                continue;
+            }
+
+            topics.push(ExtractedTopic {
+                section_type: normalise_title(&section.section_type),
+                title: normalise_title(title),
+                speech_count,
+                contributors,
+            });
+        }
+    }
+
+    topics
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalise_caps_title() {
+        assert_eq!(
+            normalise_title("UPGRADING OF A ROAD IN SUBUKIA"),
+            "Upgrading Of A Road In Subukia"
+        );
+        assert_eq!(
+            normalise_title("EFFECTS OF THE ONGOING US/ISRAEL-IRAN CONFLICT"),
+            "Effects Of The Ongoing Us/israel-iran Conflict"
+        );
+    }
+}

--- a/crates/odnelazm-ingest/src/lib.rs
+++ b/crates/odnelazm-ingest/src/lib.rs
@@ -4,9 +4,11 @@ pub mod extract;
 pub mod pipeline;
 pub mod postgres;
 pub mod store;
+pub mod summarize;
 
 pub use embed::Embedder;
 pub use error::{IngestError, Result};
 pub use pipeline::{IngestPipeline, IngestStats};
 pub use postgres::PostgresStore;
 pub use store::DataStore;
+pub use summarize::{Summarizer, SummaryContext, build_prompt};

--- a/crates/odnelazm-ingest/src/lib.rs
+++ b/crates/odnelazm-ingest/src/lib.rs
@@ -1,0 +1,12 @@
+pub mod embed;
+pub mod error;
+pub mod extract;
+pub mod pipeline;
+pub mod postgres;
+pub mod store;
+
+pub use embed::Embedder;
+pub use error::{IngestError, Result};
+pub use pipeline::{IngestPipeline, IngestStats};
+pub use postgres::PostgresStore;
+pub use store::DataStore;

--- a/crates/odnelazm-ingest/src/pipeline.rs
+++ b/crates/odnelazm-ingest/src/pipeline.rs
@@ -6,7 +6,7 @@ use crate::{
     Result,
     embed::{Embedder, sitting_text},
     extract::{extract_bills, extract_speakers},
-    store::{BillMentionRecord, DataStore},
+    store::{BillMentionRecord, DataStore, MemberRecord},
 };
 
 #[derive(Debug, Default)]
@@ -252,5 +252,40 @@ impl<S: DataStore> IngestPipeline<S> {
         }
 
         Ok(total)
+    }
+
+    /// Fetch all members for a parliament session, store them, then link them
+    /// to existing speaker rows via URL match and fuzzy name match.
+    /// Returns the number of speaker→member links created.
+    pub async fn import_members(&self, parliament: &str) -> Result<u64> {
+        let members = self.scraper.list_all_members_all_houses(parliament).await?;
+        log::info!("Importing {} members for {parliament}...", members.len());
+
+        for member in &members {
+            self.store
+                .upsert_member(&MemberRecord {
+                    name: member.name.clone(),
+                    url: normalise_url(&member.url),
+                    house: member.house.to_string(),
+                    parliament: parliament.to_string(),
+                    role: member.role.clone(),
+                    constituency: member.constituency.clone(),
+                })
+                .await?;
+        }
+
+        log::info!("Members stored — running speaker linkage...");
+        let linked = self.store.link_speakers_to_members().await?;
+        log::info!("{linked} speaker rows linked to members");
+        Ok(linked)
+    }
+}
+
+fn normalise_url(url: &str) -> String {
+    let u = url.trim();
+    if u.ends_with('/') {
+        u.to_string()
+    } else {
+        format!("{u}/")
     }
 }

--- a/crates/odnelazm-ingest/src/pipeline.rs
+++ b/crates/odnelazm-ingest/src/pipeline.rs
@@ -5,8 +5,9 @@ use odnelazm::{HansardScraper, HansardSitting, SittingListOptions};
 use crate::{
     Result,
     embed::{Embedder, sitting_text},
-    extract::{extract_bills, extract_speakers},
-    store::{BillMentionRecord, DataStore, MemberRecord},
+    extract::{extract_bills, extract_speakers, extract_topics},
+    store::{BillMentionRecord, DataStore, MemberEnrichment, MemberRecord, TopicRecord},
+    summarize::{Summarizer, SummaryContext},
 };
 
 #[derive(Debug, Default)]
@@ -15,6 +16,7 @@ pub struct IngestStats {
     pub skipped: u32,
     pub failed: u32,
     pub bills_found: u32,
+    pub topics_found: u32,
     pub speakers_found: u32,
 }
 
@@ -22,8 +24,13 @@ impl std::fmt::Display for IngestStats {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "ingested={} skipped={} failed={} bills={} speakers={}",
-            self.ingested, self.skipped, self.failed, self.bills_found, self.speakers_found
+            "ingested={} skipped={} failed={} bills={} topics={} speakers={}",
+            self.ingested,
+            self.skipped,
+            self.failed,
+            self.bills_found,
+            self.topics_found,
+            self.speakers_found
         )
     }
 }
@@ -37,6 +44,7 @@ pub struct IngestPipeline<S: DataStore> {
     scraper: HansardScraper,
     store: S,
     embedder: Option<Arc<dyn Embedder>>,
+    summarizer: Option<Arc<dyn Summarizer>>,
 }
 
 impl<S: DataStore> IngestPipeline<S> {
@@ -45,11 +53,17 @@ impl<S: DataStore> IngestPipeline<S> {
             scraper,
             store,
             embedder: None,
+            summarizer: None,
         }
     }
 
     pub fn with_embedder(mut self, embedder: impl Embedder + 'static) -> Self {
         self.embedder = Some(Arc::new(embedder));
+        self
+    }
+
+    pub fn with_summarizer(mut self, summarizer: impl Summarizer + 'static) -> Self {
+        self.summarizer = Some(Arc::new(summarizer));
         self
     }
 
@@ -102,11 +116,40 @@ impl<S: DataStore> IngestPipeline<S> {
                         bill_mention_id,
                         speaker_id,
                         contributor.speech_count,
+                        &contributor.contributions_text,
                     )
                     .await?;
             }
         }
         stats.bills_found = mentions.len() as u32;
+
+        // 4. Extract and store topics (questions, statements, motions), statements, and other topics
+        let extracted_topics = extract_topics(&sitting);
+        for topic in &extracted_topics {
+            let topic_id = self
+                .store
+                .upsert_topic(&TopicRecord {
+                    sitting_id,
+                    section_type: topic.section_type.clone(),
+                    title: topic.title.clone(),
+                    speech_count: topic.speech_count,
+                })
+                .await?;
+
+            for contributor in &topic.contributors {
+                let speaker_id = self.store.upsert_speaker(&contributor.speaker).await?;
+                self.store
+                    .link_speaker_to_topic(
+                        topic_id,
+                        speaker_id,
+                        contributor.speech_count,
+                        &contributor.contributions_text,
+                    )
+                    .await?;
+            }
+        }
+
+        stats.topics_found = extracted_topics.len() as u32;
 
         // Generate and store embedding (if embedder is configured)
         if let Some(embedder) = &self.embedder {
@@ -167,6 +210,7 @@ impl<S: DataStore> IngestPipeline<S> {
                         Ok(stats) => {
                             total.ingested += stats.ingested;
                             total.bills_found += stats.bills_found;
+                            total.topics_found += stats.topics_found;
                             total.speakers_found += stats.speakers_found;
                             log::info!("✓ {}", listing.url);
                         }
@@ -235,6 +279,7 @@ impl<S: DataStore> IngestPipeline<S> {
                         Ok(stats) => {
                             total.ingested += stats.ingested;
                             total.bills_found += stats.bills_found;
+                            total.topics_found += stats.topics_found;
                             total.speakers_found += stats.speakers_found;
                             log::info!("✓ {}", listing.url);
                         }
@@ -257,6 +302,85 @@ impl<S: DataStore> IngestPipeline<S> {
     /// Fetch all members for a parliament session, store them, then link them
     /// to existing speaker rows via URL match and fuzzy name match.
     /// Returns the number of speaker→member links created.
+    /// Generate and store AI summaries for pending (member, bill) and (member, topic) pairs.
+    ///
+    /// Requires a [`Summarizer`] attached via [`IngestPipeline::with_summarizer`].
+    /// Safe to call incrementally — only rows with `contributions_text IS NOT NULL
+    /// AND summary IS NULL` are processed.
+    ///
+    /// Returns `(bill_summaries, topic_summaries)` generated in this run.
+    pub async fn enrich_summaries(&self, batch_size: u32) -> Result<(u64, u64)> {
+        let Some(summarizer) = &self.summarizer else {
+            log::warn!("enrich_summaries called but no Summarizer is configured");
+            return Ok((0, 0));
+        };
+
+        let mut bill_count = 0u64;
+        let pending_bills = self.store.pending_bill_summaries(batch_size).await?;
+        log::info!("Summarising {} bill contributions...", pending_bills.len());
+        for p in &pending_bills {
+            let ctx = SummaryContext {
+                member_name: p
+                    .member_name
+                    .clone()
+                    .unwrap_or_else(|| "Unknown member".into()),
+                title: p.bill_name.clone(),
+                item_type: "bill".into(),
+                stage: p.stage.clone(),
+                date: p.date,
+                house: p.house.clone(),
+            };
+            match summarizer.summarize(&ctx, &p.contributions_text).await {
+                Ok(summary) => {
+                    self.store
+                        .store_bill_mention_summary(p.bill_mention_id, p.speaker_id, &summary)
+                        .await?;
+                    bill_count += 1;
+                }
+                Err(e) => log::warn!(
+                    "Bill summary failed ({} / {}): {e}",
+                    p.bill_name,
+                    p.member_name.as_deref().unwrap_or("?")
+                ),
+            }
+        }
+
+        let mut topic_count = 0u64;
+        let pending_topics = self.store.pending_topic_summaries(batch_size).await?;
+        log::info!(
+            "Summarising {} topic contributions...",
+            pending_topics.len()
+        );
+        for p in &pending_topics {
+            let ctx = SummaryContext {
+                member_name: p
+                    .member_name
+                    .clone()
+                    .unwrap_or_else(|| "Unknown member".into()),
+                title: p.topic_title.clone(),
+                item_type: "topic".into(),
+                stage: None,
+                date: p.date,
+                house: p.house.clone(),
+            };
+            match summarizer.summarize(&ctx, &p.contributions_text).await {
+                Ok(summary) => {
+                    self.store
+                        .store_topic_summary(p.topic_id, p.speaker_id, &summary)
+                        .await?;
+                    topic_count += 1;
+                }
+                Err(e) => log::warn!(
+                    "Topic summary failed ({} / {}): {e}",
+                    p.topic_title,
+                    p.member_name.as_deref().unwrap_or("?")
+                ),
+            }
+        }
+
+        Ok((bill_count, topic_count))
+    }
+
     pub async fn import_members(&self, parliament: &str) -> Result<u64> {
         let members = self.scraper.list_all_members_all_houses(parliament).await?;
         log::info!("Importing {} members for {parliament}...", members.len());
@@ -278,6 +402,58 @@ impl<S: DataStore> IngestPipeline<S> {
         let linked = self.store.link_speakers_to_members().await?;
         log::info!("{linked} speaker rows linked to members");
         Ok(linked)
+    }
+
+    /// Fetch individual profile pages for all stored members and enrich the DB
+    /// with photo, biography, party, committees, and speech statistics.
+    /// Safe to re-run — uses COALESCE so existing values are not overwritten.
+    pub async fn enrich_member_profiles(&self, concurrency: usize) -> Result<u64> {
+        let members = self.store.list_member_urls().await?;
+        log::info!("Enriching {} member profiles...", members.len());
+        let mut enriched = 0u64;
+
+        for chunk in members.chunks(concurrency) {
+            let fetches: Vec<_> = chunk
+                .iter()
+                .map(|(id, url)| async move {
+                    let result = self
+                        .scraper
+                        .get_member_profile(&normalise_url(url), false, false)
+                        .await;
+                    (*id, result)
+                })
+                .collect();
+
+            for (member_id, result) in futures::future::join_all(fetches).await {
+                match result {
+                    Ok(profile) => {
+                        let e = MemberEnrichment {
+                            photo_url: profile.photo_url.map(|p| {
+                                if p.starts_with("http") {
+                                    p
+                                } else {
+                                    format!("https://mzalendo.com{p}")
+                                }
+                            }),
+                            biography: profile.biography,
+                            party: profile.party,
+                            positions: profile.positions,
+                            committees: profile.committees,
+                            speeches_last_year: profile.speeches_last_year,
+                            speeches_total: profile.speeches_total,
+                            bills_total: profile.bills_total,
+                        };
+                        match self.store.enrich_member(member_id, &e).await {
+                            Ok(()) => enriched += 1,
+                            Err(e) => log::warn!("Enrichment store failed for {member_id}: {e}"),
+                        }
+                    }
+                    Err(e) => log::warn!("Profile fetch failed for {member_id}: {e}"),
+                }
+            }
+        }
+
+        Ok(enriched)
     }
 }
 

--- a/crates/odnelazm-ingest/src/pipeline.rs
+++ b/crates/odnelazm-ingest/src/pipeline.rs
@@ -1,0 +1,256 @@
+use std::sync::Arc;
+
+use odnelazm::{HansardScraper, HansardSitting, SittingListOptions};
+
+use crate::{
+    Result,
+    embed::{Embedder, sitting_text},
+    extract::{extract_bills, extract_speakers},
+    store::{BillMentionRecord, DataStore},
+};
+
+#[derive(Debug, Default)]
+pub struct IngestStats {
+    pub ingested: u32,
+    pub skipped: u32,
+    pub failed: u32,
+    pub bills_found: u32,
+    pub speakers_found: u32,
+}
+
+impl std::fmt::Display for IngestStats {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "ingested={} skipped={} failed={} bills={} speakers={}",
+            self.ingested, self.skipped, self.failed, self.bills_found, self.speakers_found
+        )
+    }
+}
+
+/// Orchestrates scraping → extraction → storage for a stream of sittings.
+///
+/// `S` is any [`DataStore`] implementation. An optional [`Embedder`] can be
+/// attached with [`IngestPipeline::with_embedder`]; if none is provided the
+/// embedding step is silently skipped.
+pub struct IngestPipeline<S: DataStore> {
+    scraper: HansardScraper,
+    store: S,
+    embedder: Option<Arc<dyn Embedder>>,
+}
+
+impl<S: DataStore> IngestPipeline<S> {
+    pub fn new(scraper: HansardScraper, store: S) -> Self {
+        Self {
+            scraper,
+            store,
+            embedder: None,
+        }
+    }
+
+    pub fn with_embedder(mut self, embedder: impl Embedder + 'static) -> Self {
+        self.embedder = Some(Arc::new(embedder));
+        self
+    }
+
+    /// Ingest a single fully-fetched sitting. This is the core unit of work;
+    /// all other ingest methods funnel through here.
+    pub async fn ingest_sitting(&self, sitting: HansardSitting) -> Result<IngestStats> {
+        let mut stats = IngestStats::default();
+
+        let sitting_id = self.store.upsert_sitting(&sitting).await?;
+
+        // Extract, store speakers and link speakers to sitting
+        let speakers = extract_speakers(&sitting);
+        for (speaker, speech_count) in &speakers {
+            let speaker_id = self.store.upsert_speaker(speaker).await?;
+            self.store
+                .link_speaker_to_sitting(speaker_id, sitting_id, *speech_count)
+                .await?;
+        }
+        stats.speakers_found = speakers.len() as u32;
+
+        // Extract and store bill mentions + per-bill contributors
+        let mentions = extract_bills(&sitting);
+        for mention in &mentions {
+            let bill_id = self.store.upsert_bill(&mention.bill).await?;
+            let bill_mention_id = self
+                .store
+                .upsert_bill_mention(
+                    bill_id,
+                    &BillMentionRecord {
+                        sitting_id,
+                        house: sitting.house.to_string(),
+                        date: sitting.date,
+                        stage: mention.stage.clone(),
+                        section_title: mention.section_title.clone(),
+                        speech_count: mention.speech_count,
+                    },
+                )
+                .await?;
+
+            for contributor in &mention.contributors {
+                let speaker_id = self
+                    .store
+                    .upsert_speaker(&crate::store::SpeakerRecord {
+                        name: contributor.name.clone(),
+                        url: contributor.url.clone(),
+                    })
+                    .await?;
+                self.store
+                    .link_speaker_to_bill_mention(
+                        bill_mention_id,
+                        speaker_id,
+                        contributor.speech_count,
+                    )
+                    .await?;
+            }
+        }
+        stats.bills_found = mentions.len() as u32;
+
+        // Generate and store embedding (if embedder is configured)
+        if let Some(embedder) = &self.embedder {
+            let text = sitting_text(&sitting);
+            let embedding = embedder.embed(&text).await?;
+            self.store
+                .store_sitting_embedding(sitting_id, embedding)
+                .await?;
+        }
+
+        stats.ingested = 1;
+        Ok(stats)
+    }
+
+    /// Fetch all current-source sittings, skip those already ingested, and
+    /// process the rest. Sittings are fetched and ingested in batches of
+    /// `concurrency` at a time to avoid hammering the source.
+    pub async fn ingest_all(&self, concurrency: usize) -> Result<IngestStats> {
+        let listings = self
+            .scraper
+            .list_sittings(SittingListOptions {
+                all: true,
+                ..Default::default()
+            })
+            .await?;
+
+        let ingested_urls: std::collections::HashSet<String> =
+            self.store.list_ingested_urls().await?.into_iter().collect();
+
+        let new_listings: Vec<_> = listings
+            .into_iter()
+            .filter(|l| !ingested_urls.contains(&l.url))
+            .collect();
+
+        log::info!(
+            "{} sittings total — {} already ingested — {} to process",
+            ingested_urls.len() + new_listings.len(),
+            ingested_urls.len(),
+            new_listings.len(),
+        );
+
+        let mut total = IngestStats {
+            skipped: ingested_urls.len() as u32,
+            ..Default::default()
+        };
+
+        for chunk in new_listings.chunks(concurrency) {
+            let fetches: Vec<_> = chunk
+                .iter()
+                .map(|listing| self.scraper.get_sitting(&listing.url))
+                .collect();
+
+            let results = futures::future::join_all(fetches).await;
+
+            for (listing, result) in chunk.iter().zip(results) {
+                match result {
+                    Ok(sitting) => match self.ingest_sitting(sitting).await {
+                        Ok(stats) => {
+                            total.ingested += stats.ingested;
+                            total.bills_found += stats.bills_found;
+                            total.speakers_found += stats.speakers_found;
+                            log::info!("✓ {}", listing.url);
+                        }
+                        Err(e) => {
+                            log::warn!("Ingest failed for {}: {e}", listing.url);
+                            total.failed += 1;
+                        }
+                    },
+                    Err(e) => {
+                        log::warn!("Fetch failed for {}: {e}", listing.url);
+                        total.failed += 1;
+                    }
+                }
+            }
+        }
+
+        Ok(total)
+    }
+
+    /// Ingest sittings within a specific date range, skipping already-stored ones.
+    pub async fn ingest_range(
+        &self,
+        start: chrono::NaiveDate,
+        end: chrono::NaiveDate,
+        concurrency: usize,
+    ) -> Result<IngestStats> {
+        let listings = self
+            .scraper
+            .list_sittings(SittingListOptions {
+                start_date: Some(start),
+                end_date: Some(end),
+                all: true,
+                ..Default::default()
+            })
+            .await?;
+
+        let ingested_urls: std::collections::HashSet<String> =
+            self.store.list_ingested_urls().await?.into_iter().collect();
+
+        let new_listings: Vec<_> = listings
+            .into_iter()
+            .filter(|l| !ingested_urls.contains(&l.url))
+            .collect();
+
+        log::info!(
+            "Date range {start}–{end}: {} new sittings to ingest",
+            new_listings.len()
+        );
+
+        let mut total = IngestStats {
+            skipped: ingested_urls.len() as u32,
+            ..Default::default()
+        };
+
+        for chunk in new_listings.chunks(concurrency) {
+            let fetches: Vec<_> = chunk
+                .iter()
+                .map(|listing| self.scraper.get_sitting(&listing.url))
+                .collect();
+
+            let results = futures::future::join_all(fetches).await;
+
+            for (listing, result) in chunk.iter().zip(results) {
+                match result {
+                    Ok(sitting) => match self.ingest_sitting(sitting).await {
+                        Ok(stats) => {
+                            total.ingested += stats.ingested;
+                            total.bills_found += stats.bills_found;
+                            total.speakers_found += stats.speakers_found;
+                            log::info!("✓ {}", listing.url);
+                        }
+                        Err(e) => {
+                            log::warn!("Ingest failed for {}: {e}", listing.url);
+                            total.failed += 1;
+                        }
+                    },
+                    Err(e) => {
+                        log::warn!("Fetch failed for {}: {e}", listing.url);
+                        total.failed += 1;
+                    }
+                }
+            }
+        }
+
+        Ok(total)
+    }
+}

--- a/crates/odnelazm-ingest/src/postgres.rs
+++ b/crates/odnelazm-ingest/src/postgres.rs
@@ -1,0 +1,205 @@
+use async_trait::async_trait;
+use sqlx::PgPool;
+use uuid::Uuid;
+
+use odnelazm::HansardSitting;
+
+use crate::{
+    Result,
+    store::{BillMentionRecord, BillRecord, DataStore, SpeakerRecord},
+};
+
+const MIGRATIONS: &str = concat!(
+    include_str!("../migrations/0001_init.sql"),
+    "\n",
+    include_str!("../migrations/0002_bill_speakers.sql"),
+);
+
+#[derive(Debug, Clone)]
+pub struct PostgresStore {
+    pool: PgPool,
+}
+
+impl PostgresStore {
+    pub async fn connect(database_url: &str) -> Result<Self> {
+        let pool = PgPool::connect(database_url).await?;
+        Ok(Self { pool })
+    }
+
+    pub fn from_pool(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl DataStore for PostgresStore {
+    async fn migrate(&self) -> Result<()> {
+        sqlx::raw_sql(MIGRATIONS).execute(&self.pool).await?;
+        Ok(())
+    }
+
+    async fn upsert_sitting(&self, sitting: &HansardSitting) -> Result<Uuid> {
+        let raw_json = serde_json::to_value(sitting)?;
+        let house = sitting.house.to_string();
+        let source = sitting.source.to_string();
+
+        let row: (Uuid,) = sqlx::query_as(
+            r#"
+            INSERT INTO sittings
+                (id, url, house, date, session_type, source, summary, sentiment, pdf_url, raw_json)
+            VALUES
+                (uuid_generate_v4(), $1, $2, $3, $4, $5, $6, $7, $8, $9)
+            ON CONFLICT (url) DO UPDATE SET
+                summary      = COALESCE(EXCLUDED.summary,   sittings.summary),
+                sentiment    = COALESCE(EXCLUDED.sentiment, sittings.sentiment),
+                pdf_url      = COALESCE(EXCLUDED.pdf_url,   sittings.pdf_url),
+                raw_json     = EXCLUDED.raw_json
+            RETURNING id
+            "#,
+        )
+        .bind(&sitting.url)
+        .bind(&house)
+        .bind(sitting.date)
+        .bind(&sitting.session_type)
+        .bind(&source)
+        .bind(sitting.summary.as_deref())
+        .bind(sitting.sentiment.as_deref())
+        .bind(sitting.pdf_url.as_deref())
+        .bind(&raw_json)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row.0)
+    }
+
+    async fn list_ingested_urls(&self) -> Result<Vec<String>> {
+        let rows: Vec<(String,)> = sqlx::query_as("SELECT url FROM sittings")
+            .fetch_all(&self.pool)
+            .await?;
+        Ok(rows.into_iter().map(|r| r.0).collect())
+    }
+
+    async fn store_sitting_embedding(&self, sitting_id: Uuid, embedding: Vec<f32>) -> Result<()> {
+        // Store as JSON array; swap to pgvector REAL[] once the extension is added.
+        let json = serde_json::to_value(&embedding)?;
+        sqlx::query("UPDATE sittings SET embedding = $1::jsonb WHERE id = $2")
+            .bind(&json)
+            .bind(sitting_id)
+            .execute(&self.pool)
+            .await?;
+        Ok(())
+    }
+
+    async fn upsert_speaker(&self, speaker: &SpeakerRecord) -> Result<Uuid> {
+        let row: (Uuid,) = sqlx::query_as(
+            r#"
+            INSERT INTO speakers (id, name, url)
+            VALUES (uuid_generate_v4(), $1, $2)
+            ON CONFLICT (name, url) DO UPDATE SET name = EXCLUDED.name
+            RETURNING id
+            "#,
+        )
+        .bind(&speaker.name)
+        .bind(speaker.url.as_deref())
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row.0)
+    }
+
+    async fn link_speaker_to_sitting(
+        &self,
+        speaker_id: Uuid,
+        sitting_id: Uuid,
+        speech_count: u32,
+    ) -> Result<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO sitting_speakers (sitting_id, speaker_id, speech_count)
+            VALUES ($1, $2, $3)
+            ON CONFLICT (sitting_id, speaker_id) DO UPDATE
+                SET speech_count = sitting_speakers.speech_count + EXCLUDED.speech_count
+            "#,
+        )
+        .bind(sitting_id)
+        .bind(speaker_id)
+        .bind(speech_count as i32)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn upsert_bill(&self, bill: &BillRecord) -> Result<Uuid> {
+        let row: (Uuid,) = sqlx::query_as(
+            r#"
+            INSERT INTO bills (id, name, bill_number, year, sponsor, updated_at)
+            VALUES (uuid_generate_v4(), $1, $2, $3, $4, now())
+            ON CONFLICT (name) DO UPDATE SET
+                bill_number = COALESCE(EXCLUDED.bill_number, bills.bill_number),
+                year        = COALESCE(EXCLUDED.year,        bills.year),
+                sponsor     = COALESCE(EXCLUDED.sponsor,     bills.sponsor),
+                updated_at  = now()
+            RETURNING id
+            "#,
+        )
+        .bind(&bill.name)
+        .bind(bill.bill_number.as_deref())
+        .bind(bill.year)
+        .bind(bill.sponsor.as_deref())
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(row.0)
+    }
+
+    async fn upsert_bill_mention(
+        &self,
+        bill_id: Uuid,
+        mention: &BillMentionRecord,
+    ) -> Result<Uuid> {
+        let row: (Uuid,) = sqlx::query_as(
+            r#"
+            INSERT INTO bill_mentions
+                (id, bill_id, sitting_id, house, date, stage, section_title, speech_count)
+            VALUES
+                (uuid_generate_v4(), $1, $2, $3, $4, $5, $6, $7)
+            ON CONFLICT (bill_id, sitting_id, stage) DO UPDATE SET
+                speech_count  = EXCLUDED.speech_count,
+                section_title = EXCLUDED.section_title
+            RETURNING id
+            "#,
+        )
+        .bind(bill_id)
+        .bind(mention.sitting_id)
+        .bind(&mention.house)
+        .bind(mention.date)
+        .bind(mention.stage.as_deref())
+        .bind(&mention.section_title)
+        .bind(mention.speech_count as i32)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row.0)
+    }
+
+    async fn link_speaker_to_bill_mention(
+        &self,
+        bill_mention_id: Uuid,
+        speaker_id: Uuid,
+        speech_count: u32,
+    ) -> Result<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO bill_mention_speakers (bill_mention_id, speaker_id, speech_count)
+            VALUES ($1, $2, $3)
+            ON CONFLICT (bill_mention_id, speaker_id) DO UPDATE
+                SET speech_count = bill_mention_speakers.speech_count + EXCLUDED.speech_count
+            "#,
+        )
+        .bind(bill_mention_id)
+        .bind(speaker_id)
+        .bind(speech_count as i32)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+}

--- a/crates/odnelazm-ingest/src/postgres.rs
+++ b/crates/odnelazm-ingest/src/postgres.rs
@@ -2,11 +2,15 @@ use async_trait::async_trait;
 use sqlx::PgPool;
 use uuid::Uuid;
 
+use chrono::NaiveDate;
 use odnelazm::HansardSitting;
 
 use crate::{
     Result,
-    store::{BillMentionRecord, BillRecord, DataStore, MemberRecord, SpeakerRecord},
+    store::{
+        BillMentionRecord, BillRecord, DataStore, MemberEnrichment, MemberRecord,
+        PendingBillSummary, PendingTopicSummary, SpeakerRecord, TopicRecord,
+    },
 };
 
 const MIGRATIONS: &str = concat!(
@@ -15,6 +19,16 @@ const MIGRATIONS: &str = concat!(
     include_str!("../migrations/0002_bill_speakers.sql"),
     "\n",
     include_str!("../migrations/0004_members.sql"),
+    "\n",
+    include_str!("../migrations/0005_topics.sql"),
+    "\n",
+    include_str!("../migrations/0006_contribution_text.sql"),
+    "\n",
+    include_str!("../migrations/0007_member_enrichment.sql"),
+    "\n",
+    include_str!("../migrations/0008_fix_bill_mentions_unique.sql"),
+    "\n",
+    include_str!("../migrations/0009_bill_sponsor_id.sql"),
 );
 
 #[derive(Debug, Clone)]
@@ -183,6 +197,204 @@ impl DataStore for PostgresStore {
         Ok(row.0)
     }
 
+    async fn upsert_topic(&self, topic: &TopicRecord) -> Result<Uuid> {
+        let row: (Uuid,) = sqlx::query_as(
+            r#"
+            INSERT INTO topics (id, sitting_id, section_type, title, speech_count)
+            VALUES (uuid_generate_v4(), $1, $2, $3, $4)
+            ON CONFLICT (sitting_id, section_type, title) DO UPDATE SET
+                speech_count = EXCLUDED.speech_count
+            RETURNING id
+            "#,
+        )
+        .bind(topic.sitting_id)
+        .bind(&topic.section_type)
+        .bind(&topic.title)
+        .bind(topic.speech_count as i32)
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row.0)
+    }
+
+    async fn link_speaker_to_topic(
+        &self,
+        topic_id: Uuid,
+        speaker_id: Uuid,
+        speech_count: u32,
+        contributions_text: &str,
+    ) -> Result<()> {
+        sqlx::query(
+            r#"
+            INSERT INTO topic_speakers (topic_id, speaker_id, speech_count, contributions_text)
+            VALUES ($1, $2, $3, $4)
+            ON CONFLICT (topic_id, speaker_id) DO UPDATE SET
+                speech_count       = EXCLUDED.speech_count,
+                contributions_text = EXCLUDED.contributions_text
+            "#,
+        )
+        .bind(topic_id)
+        .bind(speaker_id)
+        .bind(speech_count as i32)
+        .bind(contributions_text)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn pending_bill_summaries(&self, limit: u32) -> Result<Vec<PendingBillSummary>> {
+        let rows = sqlx::query_as::<
+            _,
+            (
+                Uuid,
+                Uuid,
+                Option<String>,
+                String,
+                NaiveDate,
+                String,
+                Option<String>,
+                String,
+            ),
+        >(
+            r#"
+            SELECT bms.bill_mention_id, bms.speaker_id,
+                   m.name, b.name, bm.date, bm.house, bm.stage,
+                   bms.contributions_text
+            FROM bill_mention_speakers bms
+            JOIN bill_mentions bm ON bm.id = bms.bill_mention_id
+            JOIN bills b          ON b.id  = bm.bill_id
+            JOIN speakers sp      ON sp.id = bms.speaker_id
+            LEFT JOIN members m   ON m.id  = sp.member_id
+            WHERE bms.contributions_text IS NOT NULL
+              AND bms.summary IS NULL
+            LIMIT $1
+            "#,
+        )
+        .bind(limit as i32)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(
+                |(
+                    bill_mention_id,
+                    speaker_id,
+                    member_name,
+                    bill_name,
+                    date,
+                    house,
+                    stage,
+                    contributions_text,
+                )| {
+                    PendingBillSummary {
+                        bill_mention_id,
+                        speaker_id,
+                        member_name,
+                        bill_name,
+                        date,
+                        house,
+                        stage,
+                        contributions_text,
+                    }
+                },
+            )
+            .collect())
+    }
+
+    async fn store_bill_mention_summary(
+        &self,
+        bill_mention_id: Uuid,
+        speaker_id: Uuid,
+        summary: &str,
+    ) -> Result<()> {
+        sqlx::query(
+            "UPDATE bill_mention_speakers SET summary = $1 WHERE bill_mention_id = $2 AND speaker_id = $3",
+        )
+        .bind(summary)
+        .bind(bill_mention_id)
+        .bind(speaker_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
+    async fn pending_topic_summaries(&self, limit: u32) -> Result<Vec<PendingTopicSummary>> {
+        let rows = sqlx::query_as::<
+            _,
+            (
+                Uuid,
+                Uuid,
+                Option<String>,
+                String,
+                String,
+                NaiveDate,
+                String,
+                String,
+            ),
+        >(
+            r#"
+            SELECT ts.topic_id, ts.speaker_id,
+                   m.name, t.title, t.section_type, s.date, s.house,
+                   ts.contributions_text
+            FROM topic_speakers ts
+            JOIN topics t         ON t.id  = ts.topic_id
+            JOIN sittings s       ON s.id  = t.sitting_id
+            JOIN speakers sp      ON sp.id = ts.speaker_id
+            LEFT JOIN members m   ON m.id  = sp.member_id
+            WHERE ts.contributions_text IS NOT NULL
+              AND ts.summary IS NULL
+            LIMIT $1
+            "#,
+        )
+        .bind(limit as i32)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(
+                |(
+                    topic_id,
+                    speaker_id,
+                    member_name,
+                    topic_title,
+                    section_type,
+                    date,
+                    house,
+                    contributions_text,
+                )| {
+                    PendingTopicSummary {
+                        topic_id,
+                        speaker_id,
+                        member_name,
+                        topic_title,
+                        section_type,
+                        date,
+                        house,
+                        contributions_text,
+                    }
+                },
+            )
+            .collect())
+    }
+
+    async fn store_topic_summary(
+        &self,
+        topic_id: Uuid,
+        speaker_id: Uuid,
+        summary: &str,
+    ) -> Result<()> {
+        sqlx::query(
+            "UPDATE topic_speakers SET summary = $1 WHERE topic_id = $2 AND speaker_id = $3",
+        )
+        .bind(summary)
+        .bind(topic_id)
+        .bind(speaker_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     async fn upsert_member(&self, member: &MemberRecord) -> Result<Uuid> {
         let row: (Uuid,) = sqlx::query_as(
             r#"
@@ -206,6 +418,44 @@ impl DataStore for PostgresStore {
         Ok(row.0)
     }
 
+    async fn list_member_urls(&self) -> Result<Vec<(Uuid, String)>> {
+        let rows: Vec<(Uuid, String)> = sqlx::query_as("SELECT id, url FROM members ORDER BY name")
+            .fetch_all(&self.pool)
+            .await?;
+        Ok(rows)
+    }
+
+    async fn enrich_member(&self, member_id: Uuid, e: &MemberEnrichment) -> Result<()> {
+        let positions = serde_json::to_value(&e.positions)?;
+        let committees = serde_json::to_value(&e.committees)?;
+        sqlx::query(
+            r#"
+            UPDATE members SET
+                photo_url          = COALESCE($1, photo_url),
+                biography          = COALESCE($2, biography),
+                party              = COALESCE($3, party),
+                positions          = COALESCE($4, positions),
+                committees         = COALESCE($5, committees),
+                speeches_last_year = COALESCE($6, speeches_last_year),
+                speeches_total     = COALESCE($7, speeches_total),
+                bills_total        = COALESCE($8, bills_total)
+            WHERE id = $9
+            "#,
+        )
+        .bind(e.photo_url.as_deref())
+        .bind(e.biography.as_deref())
+        .bind(e.party.as_deref())
+        .bind(&positions)
+        .bind(&committees)
+        .bind(e.speeches_last_year.map(|v| v as i32))
+        .bind(e.speeches_total.map(|v| v as i32))
+        .bind(e.bills_total.map(|v| v as i32))
+        .bind(member_id)
+        .execute(&self.pool)
+        .await?;
+        Ok(())
+    }
+
     async fn link_speakers_to_members(&self) -> Result<u64> {
         let url_linked: (i64,) = sqlx::query_as("SELECT link_speakers_by_url()")
             .fetch_one(&self.pool)
@@ -223,18 +473,21 @@ impl DataStore for PostgresStore {
         bill_mention_id: Uuid,
         speaker_id: Uuid,
         speech_count: u32,
+        contributions_text: &str,
     ) -> Result<()> {
         sqlx::query(
             r#"
-            INSERT INTO bill_mention_speakers (bill_mention_id, speaker_id, speech_count)
-            VALUES ($1, $2, $3)
-            ON CONFLICT (bill_mention_id, speaker_id) DO UPDATE
-                SET speech_count = bill_mention_speakers.speech_count + EXCLUDED.speech_count
+            INSERT INTO bill_mention_speakers (bill_mention_id, speaker_id, speech_count, contributions_text)
+            VALUES ($1, $2, $3, $4)
+            ON CONFLICT (bill_mention_id, speaker_id) DO UPDATE SET
+                speech_count       = EXCLUDED.speech_count,
+                contributions_text = EXCLUDED.contributions_text
             "#,
         )
         .bind(bill_mention_id)
         .bind(speaker_id)
         .bind(speech_count as i32)
+        .bind(contributions_text)
         .execute(&self.pool)
         .await?;
         Ok(())

--- a/crates/odnelazm-ingest/src/postgres.rs
+++ b/crates/odnelazm-ingest/src/postgres.rs
@@ -6,13 +6,15 @@ use odnelazm::HansardSitting;
 
 use crate::{
     Result,
-    store::{BillMentionRecord, BillRecord, DataStore, SpeakerRecord},
+    store::{BillMentionRecord, BillRecord, DataStore, MemberRecord, SpeakerRecord},
 };
 
 const MIGRATIONS: &str = concat!(
     include_str!("../migrations/0001_init.sql"),
     "\n",
     include_str!("../migrations/0002_bill_speakers.sql"),
+    "\n",
+    include_str!("../migrations/0004_members.sql"),
 );
 
 #[derive(Debug, Clone)]
@@ -179,6 +181,41 @@ impl DataStore for PostgresStore {
         .fetch_one(&self.pool)
         .await?;
         Ok(row.0)
+    }
+
+    async fn upsert_member(&self, member: &MemberRecord) -> Result<Uuid> {
+        let row: (Uuid,) = sqlx::query_as(
+            r#"
+            INSERT INTO members (id, name, url, house, parliament, role, constituency)
+            VALUES (uuid_generate_v4(), $1, $2, $3, $4, $5, $6)
+            ON CONFLICT (url) DO UPDATE SET
+                name         = EXCLUDED.name,
+                role         = COALESCE(EXCLUDED.role, members.role),
+                constituency = COALESCE(EXCLUDED.constituency, members.constituency)
+            RETURNING id
+            "#,
+        )
+        .bind(&member.name)
+        .bind(&member.url)
+        .bind(&member.house)
+        .bind(&member.parliament)
+        .bind(member.role.as_deref())
+        .bind(member.constituency.as_deref())
+        .fetch_one(&self.pool)
+        .await?;
+        Ok(row.0)
+    }
+
+    async fn link_speakers_to_members(&self) -> Result<u64> {
+        let url_linked: (i64,) = sqlx::query_as("SELECT link_speakers_by_url()")
+            .fetch_one(&self.pool)
+            .await?;
+
+        let name_linked: (i64,) = sqlx::query_as("SELECT link_speakers_by_name(0.45)")
+            .fetch_one(&self.pool)
+            .await?;
+
+        Ok((url_linked.0 + name_linked.0) as u64)
     }
 
     async fn link_speaker_to_bill_mention(

--- a/crates/odnelazm-ingest/src/store.rs
+++ b/crates/odnelazm-ingest/src/store.rs
@@ -6,48 +6,41 @@ use odnelazm::HansardSitting;
 
 use crate::Result;
 
-/// A speaker extracted from a sitting's contributions.
 #[derive(Debug, Clone)]
 pub struct SpeakerRecord {
-    /// Display name as it appears in the transcript.
     pub name: String,
-    /// Relative mzalendo profile URL, when present in the contribution.
     pub url: Option<String>,
 }
 
-/// A bill identified by the extractor.
 #[derive(Debug, Clone)]
 pub struct BillRecord {
-    /// Canonical, title-cased bill name used as the identity key.
-    /// e.g. "Income Tax (Amendment) Bill"
     pub name: String,
-    /// Formal bill number when extractable from contribution text.
-    /// e.g. "National Assembly Bill No.20 of 2026"
     pub bill_number: Option<String>,
     pub year: Option<i32>,
-    /// Name of the member who moved the bill (first mover in the debate).
     pub sponsor: Option<String>,
 }
 
-/// One appearance of a bill in one sitting at a particular legislative stage.
 #[derive(Debug, Clone)]
 pub struct BillMentionRecord {
     pub sitting_id: Uuid,
     pub house: String,
     pub date: NaiveDate,
-    /// Legislative stage label, e.g. "Second Reading", "Committee Stage".
     pub stage: Option<String>,
-    /// The section or subsection title this mention was found under.
     pub section_title: String,
-    /// Number of contributions in this bill's debate segment.
     pub speech_count: u32,
 }
 
-/// A canonical member of parliament from the member listing API.
+#[derive(Debug, Clone)]
+pub struct TopicRecord {
+    pub sitting_id: Uuid,
+    pub section_type: String,
+    pub title: String,
+    pub speech_count: u32,
+}
+
 #[derive(Debug, Clone)]
 pub struct MemberRecord {
     pub name: String,
-    /// Relative mzalendo profile URL, e.g. "/mps-performance/national-assembly/13th-parliament/slug/"
     pub url: String,
     pub house: String,
     pub parliament: String,
@@ -55,30 +48,54 @@ pub struct MemberRecord {
     pub constituency: Option<String>,
 }
 
-/// Generic async datastore interface.
-///
-/// Implement this trait to plug in any backend (PostgreSQL, SQLite, in-memory,
-/// etc.). Every method is idempotent — calling it multiple times with the same
-/// data must not create duplicates.
+/// Enrichment data fetched from a member's individual profile page.
+#[derive(Debug, Clone)]
+pub struct MemberEnrichment {
+    pub photo_url: Option<String>,
+    pub biography: Option<String>,
+    pub party: Option<String>,
+    pub positions: Vec<String>,
+    pub committees: Vec<String>,
+    pub speeches_last_year: Option<u32>,
+    pub speeches_total: Option<u32>,
+    pub bills_total: Option<u32>,
+}
+
+/// A (bill_mention, speaker) pair that has contribution text but no summary yet.
+#[derive(Debug)]
+pub struct PendingBillSummary {
+    pub bill_mention_id: Uuid,
+    pub speaker_id: Uuid,
+    pub member_name: Option<String>,
+    pub bill_name: String,
+    pub date: NaiveDate,
+    pub house: String,
+    pub stage: Option<String>,
+    pub contributions_text: String,
+}
+
+/// A (topic, speaker) pair that has contribution text but no summary yet.
+#[derive(Debug)]
+pub struct PendingTopicSummary {
+    pub topic_id: Uuid,
+    pub speaker_id: Uuid,
+    pub member_name: Option<String>,
+    pub topic_title: String,
+    pub section_type: String,
+    pub date: NaiveDate,
+    pub house: String,
+    pub contributions_text: String,
+}
+
 #[async_trait]
 pub trait DataStore: Send + Sync {
-    /// Apply schema migrations. Safe to call on every startup.
     async fn migrate(&self) -> Result<()>;
 
-    /// Persist a sitting (upsert on URL). Returns the sitting's UUID.
     async fn upsert_sitting(&self, sitting: &HansardSitting) -> Result<Uuid>;
-
-    /// Return the URLs of all sittings already in the store (used to skip
-    /// re-ingestion on subsequent pipeline runs).
     async fn list_ingested_urls(&self) -> Result<Vec<String>>;
-
-    /// Attach a pre-computed embedding vector to a sitting.
     async fn store_sitting_embedding(&self, sitting_id: Uuid, embedding: Vec<f32>) -> Result<()>;
 
-    /// Upsert a speaker (on name + url). Returns the speaker's UUID.
     async fn upsert_speaker(&self, speaker: &SpeakerRecord) -> Result<Uuid>;
-
-    /// Record that a speaker was active in a sitting, with a speech count.
     async fn link_speaker_to_sitting(
         &self,
         speaker_id: Uuid,
@@ -86,25 +103,58 @@ pub trait DataStore: Send + Sync {
         speech_count: u32,
     ) -> Result<()>;
 
-    /// Upsert a bill (on name). Returns the bill's UUID.
     async fn upsert_bill(&self, bill: &BillRecord) -> Result<Uuid>;
-
-    /// Record one appearance of a bill in a sitting. Returns the bill_mention UUID.
     async fn upsert_bill_mention(&self, bill_id: Uuid, mention: &BillMentionRecord)
     -> Result<Uuid>;
-
-    /// Record that a speaker contributed to a specific bill mention.
     async fn link_speaker_to_bill_mention(
         &self,
         bill_mention_id: Uuid,
         speaker_id: Uuid,
         speech_count: u32,
+        contributions_text: &str,
     ) -> Result<()>;
 
-    /// Upsert a member (on url). Returns the member's UUID.
-    async fn upsert_member(&self, member: &MemberRecord) -> Result<Uuid>;
+    async fn upsert_topic(&self, topic: &TopicRecord) -> Result<Uuid>;
+    async fn link_speaker_to_topic(
+        &self,
+        topic_id: Uuid,
+        speaker_id: Uuid,
+        speech_count: u32,
+        contributions_text: &str,
+    ) -> Result<()>;
 
-    /// Wire speakers to members via URL match, then fuzzy name match.
-    /// Returns the number of new links created.
+    async fn upsert_member(&self, member: &MemberRecord) -> Result<Uuid>;
     async fn link_speakers_to_members(&self) -> Result<u64>;
+
+    /// Return all (id, url) pairs for stored members — used by the enrichment pass.
+    async fn list_member_urls(&self) -> Result<Vec<(Uuid, String)>>;
+
+    /// Enrich an existing member row with profile-page data.
+    async fn enrich_member(&self, member_id: Uuid, enrichment: &MemberEnrichment) -> Result<()>;
+
+    // ── Enrichment ────────────────────────────────────────────────────────────
+
+    /// Return up to `limit` (bill_mention, speaker) pairs that have
+    /// contributions_text but no summary yet.
+    async fn pending_bill_summaries(&self, limit: u32) -> Result<Vec<PendingBillSummary>>;
+
+    /// Persist an AI-generated summary for a bill mention speaker row.
+    async fn store_bill_mention_summary(
+        &self,
+        bill_mention_id: Uuid,
+        speaker_id: Uuid,
+        summary: &str,
+    ) -> Result<()>;
+
+    /// Return up to `limit` (topic, speaker) pairs that have
+    /// contributions_text but no summary yet.
+    async fn pending_topic_summaries(&self, limit: u32) -> Result<Vec<PendingTopicSummary>>;
+
+    /// Persist an AI-generated summary for a topic speaker row.
+    async fn store_topic_summary(
+        &self,
+        topic_id: Uuid,
+        speaker_id: Uuid,
+        summary: &str,
+    ) -> Result<()>;
 }

--- a/crates/odnelazm-ingest/src/store.rs
+++ b/crates/odnelazm-ingest/src/store.rs
@@ -1,0 +1,91 @@
+use async_trait::async_trait;
+use chrono::NaiveDate;
+use uuid::Uuid;
+
+use odnelazm::HansardSitting;
+
+use crate::Result;
+
+/// A speaker extracted from a sitting's contributions.
+#[derive(Debug, Clone)]
+pub struct SpeakerRecord {
+    /// Display name as it appears in the transcript.
+    pub name: String,
+    /// Relative mzalendo profile URL, when present in the contribution.
+    pub url: Option<String>,
+}
+
+/// A bill identified by the extractor.
+#[derive(Debug, Clone)]
+pub struct BillRecord {
+    /// Canonical, title-cased bill name used as the identity key.
+    /// e.g. "Income Tax (Amendment) Bill"
+    pub name: String,
+    /// Formal bill number when extractable from contribution text.
+    /// e.g. "National Assembly Bill No.20 of 2026"
+    pub bill_number: Option<String>,
+    pub year: Option<i32>,
+    /// Name of the member who moved the bill (first mover in the debate).
+    pub sponsor: Option<String>,
+}
+
+/// One appearance of a bill in one sitting at a particular legislative stage.
+#[derive(Debug, Clone)]
+pub struct BillMentionRecord {
+    pub sitting_id: Uuid,
+    pub house: String,
+    pub date: NaiveDate,
+    /// Legislative stage label, e.g. "Second Reading", "Committee Stage".
+    pub stage: Option<String>,
+    /// The section or subsection title this mention was found under.
+    pub section_title: String,
+    /// Number of contributions in this bill's debate segment.
+    pub speech_count: u32,
+}
+
+/// Generic async datastore interface.
+///
+/// Implement this trait to plug in any backend (PostgreSQL, SQLite, in-memory,
+/// etc.). Every method is idempotent — calling it multiple times with the same
+/// data must not create duplicates.
+#[async_trait]
+pub trait DataStore: Send + Sync {
+    /// Apply schema migrations. Safe to call on every startup.
+    async fn migrate(&self) -> Result<()>;
+
+    /// Persist a sitting (upsert on URL). Returns the sitting's UUID.
+    async fn upsert_sitting(&self, sitting: &HansardSitting) -> Result<Uuid>;
+
+    /// Return the URLs of all sittings already in the store (used to skip
+    /// re-ingestion on subsequent pipeline runs).
+    async fn list_ingested_urls(&self) -> Result<Vec<String>>;
+
+    /// Attach a pre-computed embedding vector to a sitting.
+    async fn store_sitting_embedding(&self, sitting_id: Uuid, embedding: Vec<f32>) -> Result<()>;
+
+    /// Upsert a speaker (on name + url). Returns the speaker's UUID.
+    async fn upsert_speaker(&self, speaker: &SpeakerRecord) -> Result<Uuid>;
+
+    /// Record that a speaker was active in a sitting, with a speech count.
+    async fn link_speaker_to_sitting(
+        &self,
+        speaker_id: Uuid,
+        sitting_id: Uuid,
+        speech_count: u32,
+    ) -> Result<()>;
+
+    /// Upsert a bill (on name). Returns the bill's UUID.
+    async fn upsert_bill(&self, bill: &BillRecord) -> Result<Uuid>;
+
+    /// Record one appearance of a bill in a sitting. Returns the bill_mention UUID.
+    async fn upsert_bill_mention(&self, bill_id: Uuid, mention: &BillMentionRecord)
+    -> Result<Uuid>;
+
+    /// Record that a speaker contributed to a specific bill mention.
+    async fn link_speaker_to_bill_mention(
+        &self,
+        bill_mention_id: Uuid,
+        speaker_id: Uuid,
+        speech_count: u32,
+    ) -> Result<()>;
+}

--- a/crates/odnelazm-ingest/src/store.rs
+++ b/crates/odnelazm-ingest/src/store.rs
@@ -43,6 +43,18 @@ pub struct BillMentionRecord {
     pub speech_count: u32,
 }
 
+/// A canonical member of parliament from the member listing API.
+#[derive(Debug, Clone)]
+pub struct MemberRecord {
+    pub name: String,
+    /// Relative mzalendo profile URL, e.g. "/mps-performance/national-assembly/13th-parliament/slug/"
+    pub url: String,
+    pub house: String,
+    pub parliament: String,
+    pub role: Option<String>,
+    pub constituency: Option<String>,
+}
+
 /// Generic async datastore interface.
 ///
 /// Implement this trait to plug in any backend (PostgreSQL, SQLite, in-memory,
@@ -88,4 +100,11 @@ pub trait DataStore: Send + Sync {
         speaker_id: Uuid,
         speech_count: u32,
     ) -> Result<()>;
+
+    /// Upsert a member (on url). Returns the member's UUID.
+    async fn upsert_member(&self, member: &MemberRecord) -> Result<Uuid>;
+
+    /// Wire speakers to members via URL match, then fuzzy name match.
+    /// Returns the number of new links created.
+    async fn link_speakers_to_members(&self) -> Result<u64>;
 }

--- a/crates/odnelazm-ingest/src/summarize.rs
+++ b/crates/odnelazm-ingest/src/summarize.rs
@@ -1,0 +1,67 @@
+use async_trait::async_trait;
+use chrono::NaiveDate;
+
+use crate::Result;
+
+/// Context passed to the summarizer alongside the raw contribution text.
+#[derive(Debug, Clone)]
+pub struct SummaryContext {
+    pub member_name: String,
+    /// Bill name or topic title.
+    pub title: String,
+    /// "bill" | "topic"
+    pub item_type: String,
+    /// Legislative stage for bills (e.g. "Second Reading"), None for topics.
+    pub stage: Option<String>,
+    pub date: NaiveDate,
+    pub house: String,
+}
+
+/// Generate a brief summary of a member's contributions to a bill or topic.
+///
+/// Implement this trait with your preferred LLM provider. The pipeline calls
+/// [`Summarizer::summarize`] once per (member, bill/topic) pair that has
+/// `contributions_text` but no `summary` yet.
+#[async_trait]
+pub trait Summarizer: Send + Sync {
+    async fn summarize(&self, ctx: &SummaryContext, contributions_text: &str) -> Result<String>;
+}
+
+/// Build a ready-to-send prompt from the context and contribution text.
+/// Exposed so implementors can use it directly or customise it.
+pub fn build_prompt(ctx: &SummaryContext, contributions_text: &str) -> String {
+    let stage_line = ctx
+        .stage
+        .as_deref()
+        .map(|s| format!("Stage: {s}\n"))
+        .unwrap_or_default();
+
+    format!(
+        "You are analysing parliamentary contributions from the Parliament of Kenya.\n\
+         \n\
+         Member: {member}\n\
+         {item_type_label}: {title}\n\
+         {stage_line}\
+         House: {house}\n\
+         Date: {date}\n\
+         \n\
+         The member's contributions during this debate:\n\
+         ---\n\
+         {text}\n\
+         ---\n\
+         \n\
+         In 2–3 sentences, summarise this member's position, key arguments, and any \
+         notable statements. Be factual and concise. Do not invent details.",
+        member = ctx.member_name,
+        item_type_label = if ctx.item_type == "bill" {
+            "Bill"
+        } else {
+            "Topic"
+        },
+        title = ctx.title,
+        stage_line = stage_line,
+        house = ctx.house,
+        date = ctx.date,
+        text = contributions_text,
+    )
+}

--- a/crates/odnelazm/src/current/parser.rs
+++ b/crates/odnelazm/src/current/parser.rs
@@ -214,11 +214,13 @@ pub fn parse_bills_page_info(html: &str) -> Result<Option<(u32, u32)>, ParseErro
     let document = Html::parse_document(html);
 
     let active_sel = Selector::parse("nav.bills-pagination li.active_number_box span")?;
-    let current_page = document
+    let Some(current_page) = document
         .select(&active_sel)
         .next()
         .and_then(|e| normalize_whitespace(&elem_text(e)).parse::<u32>().ok())
-        .ok_or_else(|| ParseError::MissingField("Missing pagination elements".to_string()))?;
+    else {
+        return Ok(None);
+    };
 
     let link_sel = Selector::parse("nav.bills-pagination a[href]").unwrap();
     let total_pages = document
@@ -320,11 +322,13 @@ pub fn parse_activity_page_info(html: &str) -> Result<Option<(u32, u32)>, ParseE
     let document = Html::parse_document(html);
 
     let active_sel = Selector::parse("nav.contributions-pagination li.active_number_box span")?;
-    let current_page = document
+    let Some(current_page) = document
         .select(&active_sel)
         .next()
         .and_then(|e| normalize_whitespace(&elem_text(e)).parse::<u32>().ok())
-        .ok_or_else(|| ParseError::MissingField("Missing pagination elements".to_string()))?;
+    else {
+        return Ok(None);
+    };
 
     let link_sel = Selector::parse("nav.contributions-pagination a[href]").unwrap();
     let total_pages = document

--- a/crates/odnelazm/src/unified/types.rs
+++ b/crates/odnelazm/src/unified/types.rs
@@ -59,7 +59,12 @@ impl<'de> serde::Deserialize<'de> for DataSource {
             "current" | "https://mzalendo.com" => Ok(DataSource::Current),
             other => Err(serde::de::Error::unknown_variant(
                 other,
-                &["archive", "current", "https://info.mzalendo.com", "https://mzalendo.com"],
+                &[
+                    "archive",
+                    "current",
+                    "https://info.mzalendo.com",
+                    "https://mzalendo.com",
+                ],
             )),
         }
     }

--- a/crates/odnelazm/src/unified/types.rs
+++ b/crates/odnelazm/src/unified/types.rs
@@ -30,8 +30,7 @@ pub struct SittingListOptions {
 pub use crate::current::types::{Bill, Member, MemberProfile, ParliamentaryActivity, VoteRecord};
 pub use crate::types::House;
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize)]
-#[serde(rename_all = "snake_case")]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum DataSource {
     Archive,
     Current,
@@ -49,6 +48,20 @@ impl Display for DataSource {
 impl Serialize for DataSource {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
         serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for DataSource {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let s = String::deserialize(deserializer)?;
+        match s.as_str() {
+            "archive" | "https://info.mzalendo.com" => Ok(DataSource::Archive),
+            "current" | "https://mzalendo.com" => Ok(DataSource::Current),
+            other => Err(serde::de::Error::unknown_variant(
+                other,
+                &["archive", "current", "https://info.mzalendo.com", "https://mzalendo.com"],
+            )),
+        }
     }
 }
 


### PR DESCRIPTION
Introduces a new `odnelazm-ingest` crate that ingests parliamentary sitting data into a relational store with automatic bill and speaker extraction.

**Key additions**
  - `DataStore` trait — generic async interface over any backend; every method is idempotent (upsert semantics throughout)
  - `PostgresStore` — sqlx implementation with two migrations; stores sittings (including full raw JSON transcript), bills, bill mentions, speakers, and their cross-references
  - Bill extractor — pattern-based; identifies bills from section/ subsection titles, infers legislative stage, extracts bill number and sponsor from contribution text
  - Speaker extractor — tallies per-sitting and per-bill-mention speech counts from contribution records
  - `Embedder` trait + `sitting_text()` helper — ready for any embedding provider; embeddings stored as JSONB for now, pgvector-ready
  - `IngestPipeline<S: DataStore>` — orchestrates scrape → extract → store with configurable concurrency; `ingest_all` and `ingest_range` skip already-ingested sittings for safe re-runs
  - `ingest` binary — driven by DATABASE_URL, START_DATE, END_DATE, CONCURRENCY env vars
  - Fix `DataSource` Deserialize to accept both URL form ("https://mzalendo.com"\) and snake_case form ("current") so serialised JSON round-trips correctly